### PR TITLE
Fix parameter type issue.

### DIFF
--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -74,6 +74,7 @@ public class CodeFormatter {
         context["pathParams"] = operation.getParameters(type: .path).map(getParameterContext)
         context["queryParams"] = operation.getParameters(type: .query).map(getParameterContext)
         context["formParams"] = operation.getParameters(type: .form).map(getParameterContext)
+        context["headerParams"] = operation.getParameters(type: .header).map(getParameterContext)
         context["enums"] = operation.enums.map(getParameterContext)
         context["security"] = operation.security.map(getSecurityContext).first
         context["responses"] = operation.responses.map(getResponseContext)

--- a/Sources/Swagger/Operation.swift
+++ b/Sources/Swagger/Operation.swift
@@ -78,7 +78,8 @@ public class Parameter: Value {
         case body
         case path
         case query
-        case form
+        case form = "formData"
+        case header
     }
 
     required public init(jsonDictionary: JSONDictionary) throws {


### PR DESCRIPTION
This is a great Project. I like it very much. I found some issue when  I try to generate my project using SwagGen.  Below is my fix for parameter types.

## Change Log.
1. add header parameter type support
2. form parameter should be fromData.

## Reason
There are five possible parameter types.
- Path
- Query
- Header
- Body
- Form

there are only four in enum `ParamaterType`, Header is missing. Although sometimes we need set header additionally,  I think the generator should provide this ability.

The type string in the parameter object of type *"Form"* is *fromData*, So formParams is always empty.
<table>
<tr>
<td><a name="parameterIn"></a>in</td>
<td style="text-align: center;"><code>string</code></td>
<td><strong>Required.</strong> The location of the parameter. Possible values are "query", "header", "path", *"formData"* or "body".</td>
</tr>
</table>
reference: http://swagger.io/specification/#parameter-object-44