### PR TITLE
Add option for leaving dot files while cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,22 @@ If you want to pass the required arguments when running in XCode, you can edit t
 Use `SwagGen -help` to see the list of options:
 
 - **spec** (required): This is the path to the Swagger spec. It can either be a file path or a web url to a YAML or JSON file
-- **template** (required): This is the path to the template config yaml file. It can either be a direct path to the file, or a path to the parent directory which will by default look for `/template.yml`
-- **destination** The directory that the generated files will be added to.
+- **template**: (required): This is the path to the template config yaml file. It can either be a direct path to the file, or a path to the parent directory which will by default look for `/template.yml`
+- **destination**: The directory that the generated files will be added to.
 - **option**: An option that will be merged with the template config options with those in this argument taking precedence, meaning any existing options of the same name will be overwritten. This argument can be repeated to pass in multiple options. Options must specify the option name and option value seperated by a colon, with any spaces contained in quotes. The following formats are allowed: 
 	- `-- option myOption:myValue`
 	- `-- option "myOption: my value"`
 	- `-- option myOption:" my value"`
 
-- **clean** true or false - whether the destination directory is cleaned before the generated files are created. Defaults to false
-
+- **clean**: Controls if and how the destination directory is cleaned of non generated files. Options are:
+	- `none`: no files are removed (default)
+	- `all`: all other files are removed
+	- `leave.files`: all files and directories except those that start with `.` in the destination directory are removed. This is useful for keeping configuration files and directories such as `.git` around, while still making sure that items removed from the spec are removed from the generated API.
+ 
 Example:
 
 ```
-SwagGen --template Templates/Swift --spec http://myapi.com/spec --destination generated --option name:MyAPI --option "customProperty: custom value"
+SwagGen --template Templates/Swift --spec http://myapi.com/spec --destination generated --option name:MyAPI --option "customProperty: custom value --clean leave.files"
 ```
 
 For the Swift template, a handy option is `name`, which changes the name of the generated framework from the default of `API`. This can be set in the template or by passing in `--option name:MyCoolAPI`. 

--- a/Sources/SwagGen/Generate.swift
+++ b/Sources/SwagGen/Generate.swift
@@ -11,7 +11,7 @@ import Swagger
 import SwagGenKit
 import PathKit
 
-func generate(templatePath: String, destinationPath: Path, specPath: String, clean: Bool, options: [String]) {
+func generate(templatePath: String, destinationPath: Path, specPath: String, clean: Generator.Clean, options: [String]) {
 
     guard specPath != "" && URL(string: specPath) != nil else {
         writeError("Must provide a valid spec")

--- a/Sources/SwagGen/main.swift
+++ b/Sources/SwagGen/main.swift
@@ -21,11 +21,30 @@ func optionsValidator(string: String) -> String {
 
 extension Path: ArgumentConvertible {
     public init(parser: ArgumentParser) throws {
-        if let path = parser.shift() {
-            self.init(path)
-        } else {
+        guard let path = parser.shift() else {
             throw ArgumentError.missingValue(argument: nil)
         }
+        self.init(path)
+    }
+}
+
+extension Generator.Clean: ArgumentConvertible {
+
+    public init(parser: ArgumentParser) throws {
+        guard let clean = parser.shift() else {
+            throw ArgumentError.missingValue(argument: nil)
+        }
+        switch clean {
+        case "true", "yes", "all": self = .all
+        case "false", "no", "none": self = .none
+        case "leave-dot-files", "leaveDotFiles", "leave.files": self = .leaveDotFiles
+        default: throw ArgumentError.invalidType(value: clean, type: "Generator.Clean", argument: "clean")
+        }
+
+    }
+
+    public var description: String {
+        return rawValue
     }
 }
 
@@ -33,7 +52,7 @@ command(
     Option("template", "", flag: "t", description: "The path to the template json file"),
     Option("destination", Path.current + "generated", flag: "d", description: "The directory where the generated files will be created"),
     Option("spec", "", flag: "s", description: "The path or url to a swagger spec json file"),
-    Flag("clean", description: "Whether the destination directory will be cleared before generating", default: false),
+    Option("clean", .none, flag: "c", description: "How the destination directory will be cleaned of non generated files:\nnone: no files will be removed\nleave.files: all other files will be removed except if starting with . in the destination directory\nall: all other files will be removed"),
     VariadicOption("option", [] as [String], description: "An option that will be merged with template options. Can be repeated multiple times"),
     generate)
     .run()


### PR DESCRIPTION
This changes the `--clean` argument to an enum:
- `none`
- `all`
- `leave.files`

`leave.files` removes all other files except those beginning with `.` (useful for .`git`)