### PR TITLE
#24 Generate operations if they don't have any tag

### DIFF
--- a/Sources/Swagger/SwaggerSpec.swift
+++ b/Sources/Swagger/SwaggerSpec.swift
@@ -36,6 +36,15 @@ public class SwaggerSpec: JSONObjectConvertible, CustomStringConvertible {
     public var opererationsByTag: [String: [Operation]] {
         var dictionary: [String: [Operation]] = [:]
 
+        if tags.isEmpty {
+            dictionary[""] = operations
+            return dictionary
+        }
+
+        let operationWithoutTag = operations.filter { $0.tags.isEmpty }
+        dictionary[""] = operationWithoutTag
+
+
         for tag in tags {
             dictionary[tag] = operations.filter { $0.tags.contains(tag) }
         }

--- a/Sources/Swagger/SwaggerSpec.swift
+++ b/Sources/Swagger/SwaggerSpec.swift
@@ -36,18 +36,12 @@ public class SwaggerSpec: JSONObjectConvertible, CustomStringConvertible {
     public var opererationsByTag: [String: [Operation]] {
         var dictionary: [String: [Operation]] = [:]
 
-        if tags.isEmpty {
-            dictionary[""] = operations
-            return dictionary
-        }
-
-        let operationWithoutTag = operations.filter { $0.tags.isEmpty }
-        dictionary[""] = operationWithoutTag
-
+        dictionary[""] = operations.filter { $0.tags.isEmpty }
 
         for tag in tags {
             dictionary[tag] = operations.filter { $0.tags.contains(tag) }
         }
+        
         return dictionary
     }
 


### PR DESCRIPTION
Related to issue #24.

We can define default name in yaml file for output file if Swagger specs don't have any tag:
```yaml
- path: request.swift
  context: tags
  destination: "Sources/Requests/{% if name %}{{ name|upperCamelCase }}{% else %}YOUR_DEFAULT_NAME_HERE{% endif %}.swift"

```