### PR TITLE
Add hasFileParam, isFile to support file upload (multipart/form-data) in Moya

### DIFF
--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -107,7 +107,7 @@ public class CodeFormatter {
         context["pathParams"] = operation.getParameters(type: .path).map(getParameterContext)
         context["queryParams"] = operation.getParameters(type: .query).map(getParameterContext)
         context["formParams"] = operation.getParameters(type: .form).map(getParameterContext)
-        context["hasFileParam"] = operation.parameters.filter { $0.isFile }.count > 0
+        context["hasFileParam"] = operation.parameters.contains { $0.isFile }
         context["headerParams"] = operation.getParameters(type: .header).map(getParameterContext)
         context["enums"] = operation.enums.map(getParameterContext)
         context["securityRequirement"] = operation.securityRequirements.map(getSecurityRequirementContext).first

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -107,6 +107,7 @@ public class CodeFormatter {
         context["pathParams"] = operation.getParameters(type: .path).map(getParameterContext)
         context["queryParams"] = operation.getParameters(type: .query).map(getParameterContext)
         context["formParams"] = operation.getParameters(type: .form).map(getParameterContext)
+        context["hasFileParam"] = operation.parameters.filter { $0.isFile }.count > 0
         context["headerParams"] = operation.getParameters(type: .header).map(getParameterContext)
         context["enums"] = operation.enums.map(getParameterContext)
         context["securityRequirement"] = operation.securityRequirements.map(getSecurityRequirementContext).first
@@ -176,6 +177,7 @@ public class CodeFormatter {
         var context = getValueContext(value: parameter)
 
         context["parameterType"] = parameter.parameterType?.rawValue
+        context["isFile"] = parameter.isFile
 
         return context
     }

--- a/Sources/Swagger/Operation.swift
+++ b/Sources/Swagger/Operation.swift
@@ -96,6 +96,7 @@ public struct SecurityRequirement: JSONObjectConvertible {
 public class Parameter: Value {
 
     public var parameterType: ParamaterType?
+    public var isFile: Bool { return type == "file" }
 
     public enum ParamaterType: String {
         case body


### PR DESCRIPTION
I have to use `hasFileParam` to present Moya Task definition or not.
For `isFile`, actual I can use Stencil filter: `operation.formParams where param.type == "URL"`. But it will be more convenience when working with other languages. 

My Moya template will be  like this:
```ruby
{% if operation.hasFileParam %}
        var task: Taks {    
            var formData: [Moya.MultipartFormData] = []
            {% for param in operation.formParams where param.isFile %}

            let {{param.name}}Data: Moya.MultipartFormData(provider: .data({{param.name}}), name: "{{param.value}}", fileName: "{{param.value}}", mimeType: {{param.name}}.mimeType)

            formData.append({{param.name}}Data)
            {%  endfor %}
            return .upload(.multipart(formData))
        }
{% endif %}
```