### PR TITLE
#25 Generate Path Parameters which are defined outside method dictionary

### DIFF
--- a/Sources/Swagger/Operation.swift
+++ b/Sources/Swagger/Operation.swift
@@ -31,7 +31,7 @@ public class Operation {
     public var securityRequirements: [SecurityRequirement]
     public let json: JSONDictionary
 
-    public init(path: String, method: Method, jsonDictionary: JSONDictionary) throws {
+    public init(path: String, pathParameters: [Parameter], method: Method, jsonDictionary: JSONDictionary) throws {
         self.json = jsonDictionary
         self.method = method
         self.path = path
@@ -39,6 +39,7 @@ public class Operation {
         description = jsonDictionary.json(atKeyPath: "description")
         tags = jsonDictionary.json(atKeyPath: "tags") ?? []
         parameters = jsonDictionary.json(atKeyPath: "parameters") ?? []
+        parameters.append(contentsOf: pathParameters)
         securityRequirements = jsonDictionary.json(atKeyPath: "security") ?? []
         let responseDictionary: JSONDictionary = try jsonDictionary.json(atKeyPath: "responses")
         var responses: [Response] = []

--- a/Sources/Swagger/SwaggerSpec.swift
+++ b/Sources/Swagger/SwaggerSpec.swift
@@ -249,15 +249,18 @@ public class SwaggerSpec: JSONObjectConvertible, CustomStringConvertible {
 public class Endpoint {
 
     public let path: String
+    public let pathParameters: [Parameter]
     public let operations: [Operation]
 
     required public init(path: String, jsonDictionary: JSONDictionary) throws {
         self.path = path
+        pathParameters = jsonDictionary.json(atKeyPath: "parameters") ?? []
 
         var operations: [Operation] = []
+
         for method in jsonDictionary.keys {
             if let operationMethod = Operation.Method(rawValue: method), let dictionary = jsonDictionary[method] as? JSONDictionary {
-                let operation = try Operation(path: path, method: operationMethod, jsonDictionary: dictionary)
+                let operation = try Operation(path: path, pathParameters: pathParameters, method: operationMethod, jsonDictionary: dictionary)
                 operations.append(operation)
             }
         }


### PR DESCRIPTION
I've thought of creating OperationPath (not sure for the name) like this:
```ruby
public struct OperationPath {

    public let absolutePath: String
    public let parameters: [Parameter]

    init(path: String, parameters: [Parameter]) {
        self.absolutePath = path
        self.parameters = parameters
    }
}
```
Then in  `SwaggerSpec`:
```Ruby
      #SwaggerSpec
        var operations: [Operation] = []
        let pathParameters: [Parameter] = jsonDictionary.json(atKeyPath: "parameters") ?? []
        let operationPath = OperationPath(path: path, parameters: pathParameters)

        for method in jsonDictionary.keys {
            if let operationMethod = Operation.Method(rawValue: method), let dictionary = jsonDictionary[method] as? JSONDictionary {

                let operation = try Operation(path: operationPath, method: operationMethod, jsonDictionary: dictionary)
                operations.append(operation)
            }
        }
        self.operations = operations
```
But naming thing is hard and I temporary go with simple implement by adding `pathParameters` to Operation's initializer.

What do you think @yonaskolb ?