### PR TITLE
added typeOfArrayObject to get the object type of an array directly

### DIFF
--- a/Sources/SwagGenKit/SwiftFormatter.swift
+++ b/Sources/SwagGenKit/SwiftFormatter.swift
@@ -195,6 +195,7 @@ public class SwiftFormatter: CodeFormatter {
         let name = context["name"] as! String
 
         context["optionalType"] = type + (parameter.required ? "" : "?")
+        context["typeOfArrayObject"] = type.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
         var encodedValue = getEncodedValue(name: getName(name), type: type)
 
         if case let .other(items) = parameter.type,
@@ -236,6 +237,7 @@ public class SwiftFormatter: CodeFormatter {
         let name = context["name"] as! String
 
         context["optionalType"] = type + (property.required ? "" : "?")
+        context["typeOfArrayObject"] = type.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
         var encodedValue = getEncodedValue(name: getName(name), type: type)
 
         if !property.required, let range = encodedValue.range(of: ".") {


### PR DESCRIPTION
Beside the optionalType (which adds a '?') I have added a typeOfArrayObject which returns the raw type of a property (without the square bracket). This feature was a necessity for us to decode arrays (without the use of any other framework).