### PR TITLE
Add support for ascii encoded files, throw error non-supported encodings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /Specs/**/*.xcodeproj
 /Specs/**/Package.resolved
 /.vscode
+generated/

--- a/Sources/Swagger/SwaggerError.swift
+++ b/Sources/Swagger/SwaggerError.swift
@@ -8,6 +8,7 @@ public enum SwaggerError: Error, CustomStringConvertible {
     case invalidSchemaType(JSONDictionary)
     case invalidArraySchema([String: Any])
     case loadError(URL)
+    case parseError(String)
 
     public var description: String {
         switch self {
@@ -22,6 +23,8 @@ public enum SwaggerError: Error, CustomStringConvertible {
             return "Invalid array schema:\n\(array)"
         case let .loadError(url):
             return "Couldn't load url \(url)"
+        case let .parseError(message):
+            return "Swagger Parsing Error \(message)"
         }
     }
 }

--- a/Sources/Swagger/SwaggerSpec.swift
+++ b/Sources/Swagger/SwaggerSpec.swift
@@ -53,9 +53,15 @@ extension SwaggerSpec {
         } catch {
             throw SwaggerError.loadError(url)
         }
-        let string = String(data: data, encoding: .utf8)!
 
-        try self.init(string: string)
+        if let string = String(data: data, encoding: .utf8) {
+            try self.init(string: string)
+        } else if let string = String(data: data, encoding: .ascii) {
+            try self.init(string: string)
+        } else {
+            throw SwaggerError.parseError("Swagger doc is not utf8 or ascii encoded")
+        }
+
     }
 
     public init(path: PathKit.Path) throws {


### PR DESCRIPTION
Add new SwaggerError case for parse errors.

Don't force-unwrap potentially nil results. 

Attempt file load with `utf8` encoding as before. If it fails, try `ascii` encoding. If that fails, throw error instead of crashing with a `Illegal instruction: 4` message

I did not attempt to test any other file encodings. My file was in ascii, and this solves my issue.