### PR TITLE
Add a APIModel protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 
 ## 3.0.1
 
-### Changes
+### Added
+- Added new `modelProtocol` template option which defaults to `APIModel` #109
+
+### Fixed
 - Fixed crash in Swift template when not using any RequestBehaviours #108
 
 [Commits](https://github.com/yonaskolb/SwagGen/compare/3.0.0...3.0.1)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ mutableModels | whether model properties are mutable | `Bool` | true
 modelType | whether each model is a `struct` or `class` | `String` | class
 modelInheritance | whether models use inheritance. Must be false for structs | Bool | true
 modelNames | override model names | `[String: String]` | [:]
+modelProtocol | customize protocol name that all models conform to | `String` | APIModel
 enumNames | override enum names | `[String: String]` | [:]
 safeArrayDecoding | filter out invalid items in array instead of throwing | `Bool` | false
 safeOptionalDecoding | set invalid optionals to nil instead of throwing | `Bool` | false

--- a/Specs/Petstore/generated/Swift/Sources/Coding.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Coding.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+public protocol APIModel: Codable, Equatable { }
+
 public typealias ID = UUID
 
 public protocol ResponseDecoder {

--- a/Specs/Petstore/generated/Swift/Sources/Models/ErrorType.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Models/ErrorType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ErrorType: Codable, Equatable {
+public class ErrorType: APIModel {
 
     public var code: Int
 

--- a/Specs/Petstore/generated/Swift/Sources/Models/Pet.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Models/Pet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Pet: Codable, Equatable {
+public class Pet: APIModel {
 
     public var id: Int
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+public protocol APIModel: Codable, Equatable { }
+
 public typealias ID = UUID
 
 public protocol ResponseDecoder {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/AdditionalPropertiesClass.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/AdditionalPropertiesClass.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AdditionalPropertiesClass: Codable, Equatable {
+public class AdditionalPropertiesClass: APIModel {
 
     public var mapOfMapProperty: [String: [String: String]]?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Animal.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Animal.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Animal: Codable, Equatable {
+public class Animal: APIModel {
 
     public var className: String
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/ApiResponse.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/ApiResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ApiResponse: Codable, Equatable {
+public class ApiResponse: APIModel {
 
     public var code: Int?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/ArrayOfArrayOfNumberOnly.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ArrayOfArrayOfNumberOnly: Codable, Equatable {
+public class ArrayOfArrayOfNumberOnly: APIModel {
 
     public var arrayArrayNumber: [[Double]]?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/ArrayOfNumberOnly.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/ArrayOfNumberOnly.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ArrayOfNumberOnly: Codable, Equatable {
+public class ArrayOfNumberOnly: APIModel {
 
     public var arrayNumber: [Double]?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/ArrayTest.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/ArrayTest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ArrayTest: Codable, Equatable {
+public class ArrayTest: APIModel {
 
     public var arrayArrayOfInteger: [[Int]]?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Capitalization.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Capitalization.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Capitalization: Codable, Equatable {
+public class Capitalization: APIModel {
 
     /** Name of the pet
  */

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Category.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Category.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Category: Codable, Equatable {
+public class Category: APIModel {
 
     public var id: Int?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/ClassModel.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/ClassModel.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Model for testing model with "_class" property */
-public class ClassModel: Codable, Equatable {
+public class ClassModel: APIModel {
 
     public var `class`: String?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Client.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Client.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Client: Codable, Equatable {
+public class Client: APIModel {
 
     public var client: String?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumArrays.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumArrays.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class EnumArrays: Codable, Equatable {
+public class EnumArrays: APIModel {
 
     public enum ArrayEnum: String, Codable {
         case fish = "fish"

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumTest.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumTest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class EnumTest: Codable, Equatable {
+public class EnumTest: APIModel {
 
     public enum EnumInteger: Int, Codable {
         case _1 = 1

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/FormatTest.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/FormatTest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class FormatTest: Codable, Equatable {
+public class FormatTest: APIModel {
 
     public var number: Double
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/HasOnlyReadOnly.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/HasOnlyReadOnly.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class HasOnlyReadOnly: Codable, Equatable {
+public class HasOnlyReadOnly: APIModel {
 
     public var bar: String?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/List.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/List.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class List: Codable, Equatable {
+public class List: APIModel {
 
     public var _123List: String?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/MapTest.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/MapTest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class MapTest: Codable, Equatable {
+public class MapTest: APIModel {
 
     public enum MapOfEnumString: String, Codable {
         case upper = "UPPER"

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class MixedPropertiesAndAdditionalPropertiesClass: Codable, Equatable {
+public class MixedPropertiesAndAdditionalPropertiesClass: APIModel {
 
     public var dateTime: DateTime?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Name.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Name.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Model for testing model name same as property name */
-public class Name: Codable, Equatable {
+public class Name: APIModel {
 
     public var name: Int
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/NumberOnly.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/NumberOnly.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class NumberOnly: Codable, Equatable {
+public class NumberOnly: APIModel {
 
     public var justNumber: Double?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Order.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Order.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Order: Codable, Equatable {
+public class Order: APIModel {
 
     /** Order Status */
     public enum Status: String, Codable {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Pet.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Pet.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Pet: Codable, Equatable {
+public class Pet: APIModel {
 
     /** pet status in the store */
     public enum Status: String, Codable {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/ReadOnlyFirst.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/ReadOnlyFirst.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ReadOnlyFirst: Codable, Equatable {
+public class ReadOnlyFirst: APIModel {
 
     public var bar: String?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Return.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Return.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Model for testing reserved words */
-public class Return: Codable, Equatable {
+public class Return: APIModel {
 
     public var `return`: Int?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Tag.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Tag.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Tag: Codable, Equatable {
+public class Tag: APIModel {
 
     public var id: Int?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/User.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/User.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class User: Codable, Equatable {
+public class User: APIModel {
 
     public var email: String?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/_200Response.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/_200Response.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Model for testing model name starting with number */
-public class _200Response: Codable, Equatable {
+public class _200Response: APIModel {
 
     public var `class`: String?
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/dollarspecialmodelName.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/dollarspecialmodelName.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class dollarspecialmodelName: Codable, Equatable {
+public class dollarspecialmodelName: APIModel {
 
     public init() {
     }

--- a/Specs/Rocket/generated/Swift/Sources/Coding.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Coding.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+public protocol APIModel: Codable, Equatable { }
+
 public typealias ID = UUID
 
 public protocol ResponseDecoder {

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccessToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccessToken.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AccessToken: Codable, Equatable {
+public class AccessToken: APIModel {
 
     /** The type of the token. */
     public enum `Type`: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/Account.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Account.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Account: Codable, Equatable {
+public class Account: APIModel {
 
     /** The id of the account. */
     public var id: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccountDevices.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccountDevices.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AccountDevices: Codable, Equatable {
+public class AccountDevices: APIModel {
 
     /** The array of registered playack devices. */
     public var devices: [Device]

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccountTokenRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccountTokenRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AccountTokenRequest: Codable, Equatable {
+public class AccountTokenRequest: APIModel {
 
     /** The scope(s) of the tokens required.
     For each scope listed an Account and Profile token of that scope will be returned

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccountUpdateRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccountUpdateRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AccountUpdateRequest: Codable, Equatable {
+public class AccountUpdateRequest: APIModel {
 
     /** The id of the payment instrument to use by default for account transactions. */
     public var defaultPaymentInstrumentId: String?

--- a/Specs/Rocket/generated/Swift/Sources/Models/AppConfig.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AppConfig.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AppConfig: Codable, Equatable {
+public class AppConfig: APIModel {
 
     /** The map of classification ratings. */
     public var classification: [String: Classification]?

--- a/Specs/Rocket/generated/Swift/Sources/Models/AppConfigGeneral.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AppConfigGeneral.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AppConfigGeneral: Codable, Equatable {
+public class AppConfigGeneral: APIModel {
 
     /** The currency code to target. */
     public var currencyCode: String?

--- a/Specs/Rocket/generated/Swift/Sources/Models/AppConfigPlayback.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AppConfigPlayback.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AppConfigPlayback: Codable, Equatable {
+public class AppConfigPlayback: APIModel {
 
     /** How often a heartbeat should be renewed during playback. */
     public var heartbeatFrequency: Int

--- a/Specs/Rocket/generated/Swift/Sources/Models/AppConfigSubscription.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AppConfigSubscription.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AppConfigSubscription: Codable, Equatable {
+public class AppConfigSubscription: APIModel {
 
     /** The available public plans a user can subscribe to. */
     public var plans: [Plan]?

--- a/Specs/Rocket/generated/Swift/Sources/Models/Bookmark.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Bookmark.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Bookmark: Codable, Equatable {
+public class Bookmark: APIModel {
 
     /** The id of the item bookmarked. */
     public var itemId: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ChangePasswordRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ChangePasswordRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ChangePasswordRequest: Codable, Equatable {
+public class ChangePasswordRequest: APIModel {
 
     /** The new password for the account. */
     public var password: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ChangePinRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ChangePinRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ChangePinRequest: Codable, Equatable {
+public class ChangePinRequest: APIModel {
 
     /** The new pin to set. */
     public var pin: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ClassificationSummary.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ClassificationSummary.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ClassificationSummary: Codable, Equatable {
+public class ClassificationSummary: APIModel {
 
     /** The unique code for a classification. */
     public var code: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/Device.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Device.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Device: Codable, Equatable {
+public class Device: APIModel {
 
     /** The unique identifier for this device e.g. serial number. */
     public var id: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/DeviceRegistrationRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/DeviceRegistrationRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DeviceRegistrationRequest: Codable, Equatable {
+public class DeviceRegistrationRequest: APIModel {
 
     /** The unique identifier for this device e.g. serial number. */
     public var id: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/DeviceRegistrationWindow.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/DeviceRegistrationWindow.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DeviceRegistrationWindow: Codable, Equatable {
+public class DeviceRegistrationWindow: APIModel {
 
     /** The number of days a de/registration period runs for. */
     public var periodDays: Int

--- a/Specs/Rocket/generated/Swift/Sources/Models/ExclusionRule.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ExclusionRule.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Defines playback exclusion rules for an Offer or Entitlement. */
-public class ExclusionRule: Codable, Equatable {
+public class ExclusionRule: APIModel {
 
     /** Defines playback exclusion rules for an Offer or Entitlement. */
     public enum ExcludeDelivery: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/ItemCustomMetadata.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ItemCustomMetadata.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Custom metadata associated with an item. */
-public class ItemCustomMetadata: Codable, Equatable {
+public class ItemCustomMetadata: APIModel {
 
     /** The name of the custom metadata. */
     public var name: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ItemList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ItemList.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** A pageable list of items. */
-public class ItemList: Codable, Equatable {
+public class ItemList: APIModel {
 
     /** The id of this list */
     public var id: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ItemSchedule.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ItemSchedule.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ItemSchedule: Codable, Equatable {
+public class ItemSchedule: APIModel {
 
     public var id: String
 

--- a/Specs/Rocket/generated/Swift/Sources/Models/ItemScheduleList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ItemScheduleList.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ItemScheduleList: Codable, Equatable {
+public class ItemScheduleList: APIModel {
 
     /** The id of the channel the schedules belong to. */
     public var channelId: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ItemSummary.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ItemSummary.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ItemSummary: Codable, Equatable {
+public class ItemSummary: APIModel {
 
     /** Unique identifier for an Item */
     public var id: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/MediaFile.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/MediaFile.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class MediaFile: Codable, Equatable {
+public class MediaFile: APIModel {
 
     /** The way in which the media file is delivered. */
     public enum DeliveryType: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/NavContent.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/NavContent.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class NavContent: Codable, Equatable {
+public class NavContent: APIModel {
 
     /** The image type to target when rendering items of the list.
 

--- a/Specs/Rocket/generated/Swift/Sources/Models/NavEntry.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/NavEntry.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class NavEntry: Codable, Equatable {
+public class NavEntry: APIModel {
 
     /** Child nav entries. */
     public var children: [NavEntry]?

--- a/Specs/Rocket/generated/Swift/Sources/Models/Navigation.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Navigation.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Navigation: Codable, Equatable {
+public class Navigation: APIModel {
 
     /** The header navigation. */
     public var header: [NavEntry]

--- a/Specs/Rocket/generated/Swift/Sources/Models/OfferRights.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/OfferRights.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** The base type for both Offer and Entitlement. */
-public class OfferRights: Codable, Equatable {
+public class OfferRights: APIModel {
 
     /** The base type for both Offer and Entitlement. */
     public enum DeliveryType: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/PageEntry.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PageEntry.swift
@@ -9,7 +9,7 @@ import Foundation
 Defines what specific piece of content should be presented e.g. an Item or ItemList.
 Also defines what visual template should be used to render that content.
  */
-public class PageEntry: Codable, Equatable {
+public class PageEntry: APIModel {
 
     /** The type of PageEntry. Used to help identify what type of content will be presented. */
     public enum `Type`: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/PageMetadata.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PageMetadata.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Metadata associated with a page. Primarily intended for SEO usage. */
-public class PageMetadata: Codable, Equatable {
+public class PageMetadata: APIModel {
 
     public var description: String?
 

--- a/Specs/Rocket/generated/Swift/Sources/Models/PageSummary.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PageSummary.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PageSummary: Codable, Equatable {
+public class PageSummary: APIModel {
 
     /** Unique identifier for the page. */
     public var id: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/Pagination.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Pagination.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Pagination: Codable, Equatable {
+public class Pagination: APIModel {
 
     /** The total number of pages available given the current page size.
 

--- a/Specs/Rocket/generated/Swift/Sources/Models/PaginationAuth.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PaginationAuth.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PaginationAuth: Codable, Equatable {
+public class PaginationAuth: APIModel {
 
     /** The token type required to load the list. */
     public enum `Type`: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/PaginationOptions.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PaginationOptions.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PaginationOptions: Codable, Equatable {
+public class PaginationOptions: APIModel {
 
     /** Specific item type filter. */
     public var itemType: ItemType?

--- a/Specs/Rocket/generated/Swift/Sources/Models/PasswordResetEmailRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PasswordResetEmailRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PasswordResetEmailRequest: Codable, Equatable {
+public class PasswordResetEmailRequest: APIModel {
 
     /** The email address of the primary account profile to reset the password for. */
     public var email: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/PasswordResetRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PasswordResetRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PasswordResetRequest: Codable, Equatable {
+public class PasswordResetRequest: APIModel {
 
     /** The email address of the primary account profile to reset the password for. */
     public var email: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/Person.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Person.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Person: Codable, Equatable {
+public class Person: APIModel {
 
     /** The name of the person. */
     public var name: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/Plan.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Plan.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Plan: Codable, Equatable {
+public class Plan: APIModel {
 
     /** The type of plan. */
     public enum `Type`: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/ProfileCreationRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ProfileCreationRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ProfileCreationRequest: Codable, Equatable {
+public class ProfileCreationRequest: APIModel {
 
     /** The unique name of the profile. */
     public var name: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ProfileSummary.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ProfileSummary.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ProfileSummary: Codable, Equatable {
+public class ProfileSummary: APIModel {
 
     /** The id of the profile. */
     public var id: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ProfileTokenRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ProfileTokenRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ProfileTokenRequest: Codable, Equatable {
+public class ProfileTokenRequest: APIModel {
 
     /** The scope(s) of the token(s) required. */
     public enum Scopes: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/ProfileUpdateRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ProfileUpdateRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ProfileUpdateRequest: Codable, Equatable {
+public class ProfileUpdateRequest: APIModel {
 
     /** The unique name of the profile. */
     public var name: String?

--- a/Specs/Rocket/generated/Swift/Sources/Models/RegistrationRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/RegistrationRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RegistrationRequest: Codable, Equatable {
+public class RegistrationRequest: APIModel {
 
     public var email: String
 

--- a/Specs/Rocket/generated/Swift/Sources/Models/SearchResults.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/SearchResults.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class SearchResults: Codable, Equatable {
+public class SearchResults: APIModel {
 
     /** The search term. */
     public var term: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/ServiceError.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ServiceError.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ServiceError: Codable, Equatable {
+public class ServiceError: APIModel {
 
     /** A description of the error. */
     public var message: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/Subscription.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Subscription.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Subscription: Codable, Equatable {
+public class Subscription: APIModel {
 
     /** The status of a subscription. */
     public enum Status: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/TokenRefreshRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/TokenRefreshRequest.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TokenRefreshRequest: Codable, Equatable {
+public class TokenRefreshRequest: APIModel {
 
     /** If you specify a cookie type then a content filter cookie will be returned
     along with the token(s). This is only really intended for web based clients which

--- a/Specs/Rocket/generated/Swift/Sources/Models/UserRating.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/UserRating.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class UserRating: Codable, Equatable {
+public class UserRating: APIModel {
 
     /** The id of the item rated. */
     public var itemId: String

--- a/Specs/Rocket/generated/Swift/Sources/Models/Watched.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Watched.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Watched: Codable, Equatable {
+public class Watched: APIModel {
 
     /** The last playhead position watched for the item. */
     public var position: Int

--- a/Specs/TBX/generated/Swift/Sources/Coding.swift
+++ b/Specs/TBX/generated/Swift/Sources/Coding.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+public protocol APIModel: Codable, Equatable { }
+
 public typealias ID = UUID
 
 public protocol ResponseDecoder {

--- a/Specs/TBX/generated/Swift/Sources/Models/Auth.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/Auth.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Auth: Codable, Equatable {
+public class Auth: APIModel {
 
     public var status: Bool
 

--- a/Specs/TBX/generated/Swift/Sources/Models/ContentIdentityCountry.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/ContentIdentityCountry.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ContentIdentityCountry: Codable, Equatable {
+public class ContentIdentityCountry: APIModel {
 
     public var order: Double
 

--- a/Specs/TBX/generated/Swift/Sources/Models/ContentProvider.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/ContentProvider.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ContentProvider: Codable, Equatable {
+public class ContentProvider: APIModel {
 
     public var description: String
 

--- a/Specs/TBX/generated/Swift/Sources/Models/Customer.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/Customer.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Customer: Codable, Equatable {
+public class Customer: APIModel {
 
     public var subscriberID: String
 

--- a/Specs/TBX/generated/Swift/Sources/Models/Device.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/Device.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Device: Codable, Equatable {
+public class Device: APIModel {
 
     public var id: String
 

--- a/Specs/TBX/generated/Swift/Sources/Models/DeviceObject.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/DeviceObject.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DeviceObject: Codable, Equatable {
+public class DeviceObject: APIModel {
 
     public var token: String
 
@@ -18,7 +18,7 @@ public class DeviceObject: Codable, Equatable {
 
     public var description: String?
 
-    public class `Type`: Codable, Equatable {
+    public class `Type`: APIModel {
 
         public var code: String?
 
@@ -60,7 +60,7 @@ public class DeviceObject: Codable, Equatable {
         }
     }
 
-    public class Customer: Codable, Equatable {
+    public class Customer: APIModel {
 
         public var country: Country?
 
@@ -73,7 +73,7 @@ public class DeviceObject: Codable, Equatable {
 
         public var subscriberId: String?
 
-        public class Country: Codable, Equatable {
+        public class Country: APIModel {
 
             public var code: String?
 
@@ -115,7 +115,7 @@ public class DeviceObject: Codable, Equatable {
             }
         }
 
-        public class Idp: Codable, Equatable {
+        public class Idp: APIModel {
 
             public var code: String?
 

--- a/Specs/TBX/generated/Swift/Sources/Models/DeviceType.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/DeviceType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DeviceType: Codable, Equatable {
+public class DeviceType: APIModel {
 
     public var shortName: String
 

--- a/Specs/TBX/generated/Swift/Sources/Models/ErrorObject.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/ErrorObject.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ErrorObject: Codable, Equatable {
+public class ErrorObject: APIModel {
 
     /** CloudPass error code */
     public var errorCode: String

--- a/Specs/TBX/generated/Swift/Sources/Models/HasAccessToObject.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/HasAccessToObject.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class HasAccessToObject: Codable, Equatable {
+public class HasAccessToObject: APIModel {
 
     /** Target urn */
     public var urn: String

--- a/Specs/TBX/generated/Swift/Sources/Models/IdentityProvider.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/IdentityProvider.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class IdentityProvider: Codable, Equatable {
+public class IdentityProvider: APIModel {
 
     public var description: String
 

--- a/Specs/TBX/generated/Swift/Sources/Models/MSO.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/MSO.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class MSO: Codable, Equatable {
+public class MSO: APIModel {
 
     public var countryCode: String
 

--- a/Specs/TBX/generated/Swift/Sources/Models/MultiHasAccessToObject.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/MultiHasAccessToObject.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class MultiHasAccessToObject: Codable, Equatable {
+public class MultiHasAccessToObject: APIModel {
 
     public var granted: [String]
 

--- a/Specs/TBX/generated/Swift/Sources/Models/OverrideRuleObject.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/OverrideRuleObject.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class OverrideRuleObject: Codable, Equatable {
+public class OverrideRuleObject: APIModel {
 
     /** List of URNs to override */
     public var urn: [String]

--- a/Specs/TBX/generated/Swift/Sources/Models/ResponseError.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/ResponseError.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ResponseError: Codable, Equatable {
+public class ResponseError: APIModel {
 
     public var error: ErrorObject
 

--- a/Specs/TBX/generated/Swift/Sources/Models/TokenObject.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/TokenObject.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TokenObject: Codable, Equatable {
+public class TokenObject: APIModel {
 
     /** The Token ID */
     public var token: String
@@ -21,7 +21,7 @@ public class TokenObject: Codable, Equatable {
 
     public var uses: Double?
 
-    public class Idp: Codable, Equatable {
+    public class Idp: APIModel {
 
         public var code: String?
 

--- a/Specs/TBX/generated/Swift/Sources/Models/TryAndBuyObject.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/TryAndBuyObject.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TryAndBuyObject: Codable, Equatable {
+public class TryAndBuyObject: APIModel {
 
     public var active: Bool
 

--- a/Specs/TBX/generated/Swift/Sources/Models/XAny.swift
+++ b/Specs/TBX/generated/Swift/Sources/Models/XAny.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class XAny: Codable, Equatable {
+public class XAny: APIModel {
 
     public init() {
     }

--- a/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceDeleteRuleToOverrideResponse.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/AuthorizationService/AuthorizationServiceDeleteRuleToOverrideResponse.swift
@@ -46,7 +46,7 @@ extension TBX.AuthorizationService {
 
         public enum Response: APIResponseValue, CustomStringConvertible, CustomDebugStringConvertible {
 
-            public class Status200: Codable, Equatable {
+            public class Status200: APIModel {
 
                 public var status: Bool?
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceLogout.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceLogout.swift
@@ -46,7 +46,7 @@ extension TBX.UserService {
 
         public enum Response: APIResponseValue, CustomStringConvertible, CustomDebugStringConvertible {
 
-            public class Status200: Codable, Equatable {
+            public class Status200: APIModel {
 
                 public var status: Bool?
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceLogoutAll.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceLogoutAll.swift
@@ -46,7 +46,7 @@ extension TBX.UserService {
 
         public enum Response: APIResponseValue, CustomStringConvertible, CustomDebugStringConvertible {
 
-            public class Status200: Codable, Equatable {
+            public class Status200: APIModel {
 
                 public var status: Bool?
 

--- a/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceRemoveUserCache.swift
+++ b/Specs/TBX/generated/Swift/Sources/Requests/UserService/UserServiceRemoveUserCache.swift
@@ -53,7 +53,7 @@ extension TBX.UserService {
 
         public enum Response: APIResponseValue, CustomStringConvertible, CustomDebugStringConvertible {
 
-            public class Status200: Codable, Equatable {
+            public class Status200: APIModel {
 
                 public var status: Bool?
 

--- a/Specs/TFL/generated/Swift/Sources/Coding.swift
+++ b/Specs/TFL/generated/Swift/Sources/Coding.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+public protocol APIModel: Codable, Equatable { }
+
 public typealias ID = UUID
 
 public protocol ResponseDecoder {

--- a/Specs/TFL/generated/Swift/Sources/Models/AccidentDetail.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/AccidentDetail.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AccidentDetail: Codable, Equatable {
+public class AccidentDetail: APIModel {
 
     public var borough: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/AccidentStatsOrderedSummary.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/AccidentStatsOrderedSummary.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AccidentStatsOrderedSummary: Codable, Equatable {
+public class AccidentStatsOrderedSummary: APIModel {
 
     public var accidents: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/ActiveServiceType.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/ActiveServiceType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ActiveServiceType: Codable, Equatable {
+public class ActiveServiceType: APIModel {
 
     public var mode: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/AdditionalProperties.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/AdditionalProperties.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class AdditionalProperties: Codable, Equatable {
+public class AdditionalProperties: APIModel {
 
     public var category: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/ApiVersionInfo.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/ApiVersionInfo.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ApiVersionInfo: Codable, Equatable {
+public class ApiVersionInfo: APIModel {
 
     public var assemblies: [String]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Bay.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Bay.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Bay: Codable, Equatable {
+public class Bay: APIModel {
 
     public var bayCount: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/CarParkOccupancy.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/CarParkOccupancy.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class CarParkOccupancy: Codable, Equatable {
+public class CarParkOccupancy: APIModel {
 
     public var bays: [Bay]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Casualty.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Casualty.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Casualty: Codable, Equatable {
+public class Casualty: APIModel {
 
     public var age: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Coordinate.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Coordinate.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Coordinate: Codable, Equatable {
+public class Coordinate: APIModel {
 
     public var easting: Double?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Crowding.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Crowding.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Crowding: Codable, Equatable {
+public class Crowding: APIModel {
 
     /** Busiest times at a station (static information) */
     public var passengerFlows: [PassengerFlow]?

--- a/Specs/TFL/generated/Swift/Sources/Models/CycleSuperhighway.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/CycleSuperhighway.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class CycleSuperhighway: Codable, Equatable {
+public class CycleSuperhighway: APIModel {
 
     /** A LineString or MultiLineString that forms the route of the highway */
     public var geography: DbGeography?

--- a/Specs/TFL/generated/Swift/Sources/Models/DateRange.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/DateRange.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DateRange: Codable, Equatable {
+public class DateRange: APIModel {
 
     public var endDate: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/DateRangeNullable.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/DateRangeNullable.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DateRangeNullable: Codable, Equatable {
+public class DateRangeNullable: APIModel {
 
     public var endDate: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/DbGeography.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/DbGeography.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DbGeography: Codable, Equatable {
+public class DbGeography: APIModel {
 
     public var geography: DbGeographyWellKnownValue?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/DbGeographyWellKnownValue.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/DbGeographyWellKnownValue.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DbGeographyWellKnownValue: Codable, Equatable {
+public class DbGeographyWellKnownValue: APIModel {
 
     public var coordinateSystemId: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Disambiguation.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Disambiguation.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Disambiguation: Codable, Equatable {
+public class Disambiguation: APIModel {
 
     public var disambiguationOptions: [DisambiguationOption]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/DisambiguationOption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/DisambiguationOption.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DisambiguationOption: Codable, Equatable {
+public class DisambiguationOption: APIModel {
 
     public var description: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/DisruptedPoint.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/DisruptedPoint.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class DisruptedPoint: Codable, Equatable {
+public class DisruptedPoint: APIModel {
 
     public var additionalInformation: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Disruption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Disruption.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Represents a disruption to a route within the transport network. */
-public class Disruption: Codable, Equatable {
+public class Disruption: APIModel {
 
     /** Gets or sets the category of this dispruption. */
     public enum Category: String, Codable {

--- a/Specs/TFL/generated/Swift/Sources/Models/EmissionsSurchargeVehicle.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/EmissionsSurchargeVehicle.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class EmissionsSurchargeVehicle: Codable, Equatable {
+public class EmissionsSurchargeVehicle: APIModel {
 
     public enum Compliance: String, Codable {
         case notCompliant = "NotCompliant"

--- a/Specs/TFL/generated/Swift/Sources/Models/Fare.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Fare.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Fare: Codable, Equatable {
+public class Fare: APIModel {
 
     public var cap: Double?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/FareBounds.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/FareBounds.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class FareBounds: Codable, Equatable {
+public class FareBounds: APIModel {
 
     public var description: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/FareDetails.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/FareDetails.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class FareDetails: Codable, Equatable {
+public class FareDetails: APIModel {
 
     public var boundsId: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/FaresMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/FaresMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class FaresMode: Codable, Equatable {
+public class FaresMode: APIModel {
 
     public var description: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/FaresPeriod.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/FaresPeriod.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class FaresPeriod: Codable, Equatable {
+public class FaresPeriod: APIModel {
 
     public var endDate: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/FaresSection.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/FaresSection.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class FaresSection: Codable, Equatable {
+public class FaresSection: APIModel {
 
     public var header: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/GeoCodeSearchMatch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/GeoCodeSearchMatch.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class GeoCodeSearchMatch: Codable, Equatable {
+public class GeoCodeSearchMatch: APIModel {
 
     /** A string describing the formatted address of the place. Adds additional context to the place's Name. */
     public var address: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/GeoPoint.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/GeoPoint.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class GeoPoint: Codable, Equatable {
+public class GeoPoint: APIModel {
 
     public var lat: Double
 

--- a/Specs/TFL/generated/Swift/Sources/Models/GeoPointBBox.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/GeoPointBBox.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class GeoPointBBox: Codable, Equatable {
+public class GeoPointBBox: APIModel {
 
     public var swLat: Double
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Identifier.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Identifier.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Identifier: Codable, Equatable {
+public class Identifier: APIModel {
 
     public var crowding: Crowding?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Instruction.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Instruction.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Instruction: Codable, Equatable {
+public class Instruction: APIModel {
 
     public var detailed: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/InstructionStep.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/InstructionStep.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class InstructionStep: Codable, Equatable {
+public class InstructionStep: APIModel {
 
     public enum SkyDirectionDescription: String, Codable {
         case north = "North"

--- a/Specs/TFL/generated/Swift/Sources/Models/Interval.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Interval.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Interval: Codable, Equatable {
+public class Interval: APIModel {
 
     public var stopId: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/ItineraryResult.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/ItineraryResult.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** A DTO representing a list of possible journeys. */
-public class ItineraryResult: Codable, Equatable {
+public class ItineraryResult: APIModel {
 
     public var cycleHireDockingStationData: JourneyPlannerCycleHireDockingStationData?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Journey.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Journey.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Object that represents an end to end journey (see schematic). */
-public class Journey: Codable, Equatable {
+public class Journey: APIModel {
 
     public var arrivalDateTime: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/JourneyPlannerCycleHireDockingStationData.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/JourneyPlannerCycleHireDockingStationData.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class JourneyPlannerCycleHireDockingStationData: Codable, Equatable {
+public class JourneyPlannerCycleHireDockingStationData: APIModel {
 
     public var destinationId: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/JourneyVector.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/JourneyVector.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class JourneyVector: Codable, Equatable {
+public class JourneyVector: APIModel {
 
     public var from: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/JpElevation.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/JpElevation.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class JpElevation: Codable, Equatable {
+public class JpElevation: APIModel {
 
     public var distance: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/KnownJourney.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/KnownJourney.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class KnownJourney: Codable, Equatable {
+public class KnownJourney: APIModel {
 
     public var hour: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Leg.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Leg.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Leg: Codable, Equatable {
+public class Leg: APIModel {
 
     public var arrivalPoint: Point?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Line.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Line.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Line: Codable, Equatable {
+public class Line: APIModel {
 
     public var created: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/LineGroup.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/LineGroup.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class LineGroup: Codable, Equatable {
+public class LineGroup: APIModel {
 
     public var lineIdentifier: [String]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/LineModeGroup.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/LineModeGroup.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class LineModeGroup: Codable, Equatable {
+public class LineModeGroup: APIModel {
 
     public var lineIdentifier: [String]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/LineRouteSection.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/LineRouteSection.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class LineRouteSection: Codable, Equatable {
+public class LineRouteSection: APIModel {
 
     public var destination: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/LineServiceType.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/LineServiceType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class LineServiceType: Codable, Equatable {
+public class LineServiceType: APIModel {
 
     public var lineName: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/LineServiceTypeInfo.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/LineServiceTypeInfo.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class LineServiceTypeInfo: Codable, Equatable {
+public class LineServiceTypeInfo: APIModel {
 
     public var name: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/LineSpecificServiceType.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/LineSpecificServiceType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class LineSpecificServiceType: Codable, Equatable {
+public class LineSpecificServiceType: APIModel {
 
     public var serviceType: LineServiceTypeInfo?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/LineStatus.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/LineStatus.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class LineStatus: Codable, Equatable {
+public class LineStatus: APIModel {
 
     public var created: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/MatchedRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/MatchedRoute.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class MatchedRoute: Codable, Equatable {
+public class MatchedRoute: APIModel {
 
     /** eg: Destination */
     public var destination: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/MatchedRouteSections.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/MatchedRouteSections.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class MatchedRouteSections: Codable, Equatable {
+public class MatchedRouteSections: APIModel {
 
     public var id: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/MatchedStop.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/MatchedStop.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class MatchedStop: Codable, Equatable {
+public class MatchedStop: APIModel {
 
     public var accessibilitySummary: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Message.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Message.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Message: Codable, Equatable {
+public class Message: APIModel {
 
     public var bulletOrder: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Mode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Mode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Mode: Codable, Equatable {
+public class Mode: APIModel {
 
     public var isFarePaying: Bool?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Object.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Object.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Object: Codable, Equatable {
+public class Object: APIModel {
 
     public init() {
     }

--- a/Specs/TFL/generated/Swift/Sources/Models/Obstacle.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Obstacle.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Obstacle: Codable, Equatable {
+public class Obstacle: APIModel {
 
     public var incline: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/OrderedRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/OrderedRoute.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class OrderedRoute: Codable, Equatable {
+public class OrderedRoute: APIModel {
 
     public var name: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/PassengerFlow.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/PassengerFlow.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PassengerFlow: Codable, Equatable {
+public class PassengerFlow: APIModel {
 
     /** Time in 24hr format with 15 minute intervals e.g. 0500-0515, 0515-0530 etc. */
     public var timeSlice: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/PassengerType.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/PassengerType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PassengerType: Codable, Equatable {
+public class PassengerType: APIModel {
 
     public var description: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Path.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Path.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Path: Codable, Equatable {
+public class Path: APIModel {
 
     public var elevation: [JpElevation]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/PathAttribute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/PathAttribute.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PathAttribute: Codable, Equatable {
+public class PathAttribute: APIModel {
 
     public var name: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Period.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Period.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Period: Codable, Equatable {
+public class Period: APIModel {
 
     public enum `Type`: String, Codable {
         case normal = "Normal"

--- a/Specs/TFL/generated/Swift/Sources/Models/Place.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Place.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Place: Codable, Equatable {
+public class Place: APIModel {
 
     /** A bag of additional key/value pairs with extra information about this place. */
     public var additionalProperties: [AdditionalProperties]?

--- a/Specs/TFL/generated/Swift/Sources/Models/PlaceCategory.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/PlaceCategory.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PlaceCategory: Codable, Equatable {
+public class PlaceCategory: APIModel {
 
     public var availableKeys: [String]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/PlacePolygon.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/PlacePolygon.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PlacePolygon: Codable, Equatable {
+public class PlacePolygon: APIModel {
 
     public var commonName: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/PlannedWork.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/PlannedWork.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PlannedWork: Codable, Equatable {
+public class PlannedWork: APIModel {
 
     public var createdDateTime: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Point.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Point.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Represents a point located at a latitude and longitude using the WGS84 co-ordinate system. */
-public class Point: Codable, Equatable {
+public class Point: APIModel {
 
     /** WGS84 latitude of the location. */
     public var lat: Double?

--- a/Specs/TFL/generated/Swift/Sources/Models/PostcodeInput.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/PostcodeInput.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PostcodeInput: Codable, Equatable {
+public class PostcodeInput: APIModel {
 
     public var postcode: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Prediction.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Prediction.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** DTO to capture the prediction details */
-public class Prediction: Codable, Equatable {
+public class Prediction: APIModel {
 
     /** Bearing (between 0 to 359) */
     public var bearing: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/PredictionTiming.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/PredictionTiming.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class PredictionTiming: Codable, Equatable {
+public class PredictionTiming: APIModel {
 
     public var countdownServerAdjustment: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Recommendation.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Recommendation.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Recommendation: Codable, Equatable {
+public class Recommendation: APIModel {
 
     public var cost: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RecommendationResponse.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RecommendationResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RecommendationResponse: Codable, Equatable {
+public class RecommendationResponse: APIModel {
 
     public var recommendations: [Recommendation]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Redirect.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Redirect.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Redirect: Codable, Equatable {
+public class Redirect: APIModel {
 
     public var active: Bool?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RoadCorridor.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RoadCorridor.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RoadCorridor: Codable, Equatable {
+public class RoadCorridor: APIModel {
 
     /** The Bounds of the Corridor, given by the south-east followed by the north-west co-ordinate
             pair in geoJSON format e.g. "[[-1.241531,51.242151],[1.641223,53.765721]]" */

--- a/Specs/TFL/generated/Swift/Sources/Models/RoadDisruption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RoadDisruption.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RoadDisruption: Codable, Equatable {
+public class RoadDisruption: APIModel {
 
     /** Describes the nature of disruption e.g. Traffic Incidents, Works */
     public var category: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/RoadDisruptionImpactArea.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RoadDisruptionImpactArea.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RoadDisruptionImpactArea: Codable, Equatable {
+public class RoadDisruptionImpactArea: APIModel {
 
     public var endDate: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RoadDisruptionLine.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RoadDisruptionLine.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RoadDisruptionLine: Codable, Equatable {
+public class RoadDisruptionLine: APIModel {
 
     public var endDate: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RoadDisruptionSchedule.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RoadDisruptionSchedule.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RoadDisruptionSchedule: Codable, Equatable {
+public class RoadDisruptionSchedule: APIModel {
 
     public var endTime: DateTime?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RoadProject.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RoadProject.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RoadProject: Codable, Equatable {
+public class RoadProject: APIModel {
 
     public enum Phase: String, Codable {
         case unscoped = "Unscoped"

--- a/Specs/TFL/generated/Swift/Sources/Models/RouteOption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RouteOption.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RouteOption: Codable, Equatable {
+public class RouteOption: APIModel {
 
     public var directions: [String]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RouteSearchMatch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RouteSearchMatch.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RouteSearchMatch: Codable, Equatable {
+public class RouteSearchMatch: APIModel {
 
     public var id: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RouteSearchResponse.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RouteSearchResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RouteSearchResponse: Codable, Equatable {
+public class RouteSearchResponse: APIModel {
 
     public var input: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RouteSection.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RouteSection.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RouteSection: Codable, Equatable {
+public class RouteSection: APIModel {
 
     /** eg: Destination Name */
     public var destinationName: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/RouteSectionNaptanEntrySequence.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RouteSectionNaptanEntrySequence.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RouteSectionNaptanEntrySequence: Codable, Equatable {
+public class RouteSectionNaptanEntrySequence: APIModel {
 
     public var ordinal: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/RouteSequence.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RouteSequence.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class RouteSequence: Codable, Equatable {
+public class RouteSequence: APIModel {
 
     public var direction: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Schedule.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Schedule.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Schedule: Codable, Equatable {
+public class Schedule: APIModel {
 
     public var firstJourney: KnownJourney?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/SearchCriteria.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/SearchCriteria.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class SearchCriteria: Codable, Equatable {
+public class SearchCriteria: APIModel {
 
     public enum DateTimeType: String, Codable {
         case arriving = "Arriving"

--- a/Specs/TFL/generated/Swift/Sources/Models/SearchMatch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/SearchMatch.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class SearchMatch: Codable, Equatable {
+public class SearchMatch: APIModel {
 
     public var id: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/SearchResponse.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/SearchResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class SearchResponse: Codable, Equatable {
+public class SearchResponse: APIModel {
 
     public var from: Int?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/ServiceFrequency.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/ServiceFrequency.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class ServiceFrequency: Codable, Equatable {
+public class ServiceFrequency: APIModel {
 
     public var highestFrequency: Double?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/StationInterval.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StationInterval.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class StationInterval: Codable, Equatable {
+public class StationInterval: APIModel {
 
     public var id: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/StatusSeverity.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StatusSeverity.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class StatusSeverity: Codable, Equatable {
+public class StatusSeverity: APIModel {
 
     public var description: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/StopPoint.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StopPoint.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class StopPoint: Codable, Equatable {
+public class StopPoint: APIModel {
 
     public var accessibilitySummary: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/StopPointCategory.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StopPointCategory.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class StopPointCategory: Codable, Equatable {
+public class StopPointCategory: APIModel {
 
     public var availableKeys: [String]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/StopPointRouteSection.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StopPointRouteSection.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class StopPointRouteSection: Codable, Equatable {
+public class StopPointRouteSection: APIModel {
 
     public var destinationName: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/StopPointSequence.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StopPointSequence.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class StopPointSequence: Codable, Equatable {
+public class StopPointSequence: APIModel {
 
     public enum ServiceType: String, Codable {
         case regular = "Regular"

--- a/Specs/TFL/generated/Swift/Sources/Models/StopPointsResponse.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StopPointsResponse.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** A paged response containing StopPoints */
-public class StopPointsResponse: Codable, Equatable {
+public class StopPointsResponse: APIModel {
 
     /** The centre latitude/longitude of this list of StopPoints */
     public var centrePoint: [Double]?

--- a/Specs/TFL/generated/Swift/Sources/Models/Street.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Street.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Street: Codable, Equatable {
+public class Street: APIModel {
 
     /** Type of road closure. Some example values:
             Open = road is open, not blocked, not closed, not restricted. It maybe that the disruption has been moved out of the carriageway.

--- a/Specs/TFL/generated/Swift/Sources/Models/StreetSegment.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StreetSegment.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class StreetSegment: Codable, Equatable {
+public class StreetSegment: APIModel {
 
     /** geoJSON formatted LineString containing two latitude/longitude (WGS84) pairs that identify the start and end points of the street segment. */
     public var lineString: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/Ticket.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Ticket.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Ticket: Codable, Equatable {
+public class Ticket: APIModel {
 
     public var cost: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/TicketTime.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/TicketTime.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TicketTime: Codable, Equatable {
+public class TicketTime: APIModel {
 
     public var description: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/TicketType.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/TicketType.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TicketType: Codable, Equatable {
+public class TicketType: APIModel {
 
     public var description: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/TimeAdjustment.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/TimeAdjustment.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TimeAdjustment: Codable, Equatable {
+public class TimeAdjustment: APIModel {
 
     public var date: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/TimeAdjustments.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/TimeAdjustments.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TimeAdjustments: Codable, Equatable {
+public class TimeAdjustments: APIModel {
 
     public var earlier: TimeAdjustment?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/Timetable.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Timetable.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Timetable: Codable, Equatable {
+public class Timetable: APIModel {
 
     public var departureStopId: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/TimetableResponse.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/TimetableResponse.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TimetableResponse: Codable, Equatable {
+public class TimetableResponse: APIModel {
 
     public var direction: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/TimetableRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/TimetableRoute.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TimetableRoute: Codable, Equatable {
+public class TimetableRoute: APIModel {
 
     public var schedules: [Schedule]?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/TrainLoading.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/TrainLoading.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TrainLoading: Codable, Equatable {
+public class TrainLoading: APIModel {
 
     /** Direction in regards to Journey Planner i.e. inbound or outbound */
     public var direction: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/TwentyFourHourClockTime.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/TwentyFourHourClockTime.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class TwentyFourHourClockTime: Codable, Equatable {
+public class TwentyFourHourClockTime: APIModel {
 
     public var hour: String?
 

--- a/Specs/TFL/generated/Swift/Sources/Models/ValidityPeriod.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/ValidityPeriod.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** Represents a period for which a planned works is valid. */
-public class ValidityPeriod: Codable, Equatable {
+public class ValidityPeriod: APIModel {
 
     /** Gets or sets the start date. */
     public var fromDate: DateTime?

--- a/Specs/TFL/generated/Swift/Sources/Models/Vehicle.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Vehicle.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class Vehicle: Codable, Equatable {
+public class Vehicle: APIModel {
 
     public var type: String?
 

--- a/Specs/TestSpec/generated/Swift/Sources/Coding.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Coding.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+public protocol APIModel: Codable, Equatable { }
+
 public typealias ID = UUID
 
 public protocol ResponseDecoder {

--- a/Specs/TestSpec/generated/Swift/Sources/Models/ModelWithAdditionalProperties.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/ModelWithAdditionalProperties.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** definition with additional properties */
-public class ModelWithAdditionalProperties: Codable, Equatable {
+public class ModelWithAdditionalProperties: APIModel {
 
     public var name: String?
 

--- a/Specs/TestSpec/generated/Swift/Sources/Models/ModelWithBooleanAdditionalProperties.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/ModelWithBooleanAdditionalProperties.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** definition with bool additional properties */
-public class ModelWithBooleanAdditionalProperties: Codable, Equatable {
+public class ModelWithBooleanAdditionalProperties: APIModel {
 
     public var name: String?
 

--- a/Specs/TestSpec/generated/Swift/Sources/Models/ModelWithDefinitionAdditionalProperties.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/ModelWithDefinitionAdditionalProperties.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /** definition with a Definition as additional properties */
-public class ModelWithDefinitionAdditionalProperties: Codable, Equatable {
+public class ModelWithDefinitionAdditionalProperties: APIModel {
 
     public var name: String?
 

--- a/Specs/TestSpec/generated/Swift/Sources/Models/ModelWithInlineSpec.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/ModelWithInlineSpec.swift
@@ -5,12 +5,12 @@
 
 import Foundation
 
-public class ModelWithInlineSpec: Codable, Equatable {
+public class ModelWithInlineSpec: APIModel {
 
     /** an inline model */
     public var myModel: MyModel?
 
-    public class MyModel: Codable, Equatable {
+    public class MyModel: APIModel {
 
         /** name of the model */
         public var name: String?

--- a/Specs/TestSpec/generated/Swift/Sources/Models/User.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/User.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public class User: Codable, Equatable {
+public class User: APIModel {
 
     public var id: Int?
 

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/TestTag/PostInlinebody.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/TestTag/PostInlinebody.swift
@@ -17,7 +17,7 @@ extension TestSpec.TestTag {
         public final class Request: APIRequest<Response> {
 
             /** operation with an inline body */
-            public class Item: Codable, Equatable {
+            public class Item: APIModel {
 
                 public var id: Int?
 

--- a/Templates/Swift/Includes/Model.stencil
+++ b/Templates/Swift/Includes/Model.stencil
@@ -8,7 +8,7 @@ public typealias {{ type }} = {{ aliasType }}
 {% elif additionalPropertiesType and allProperties.count == 0 %}
 public typealias {{ type }} = [String: {{ additionalPropertiesType }}]
 {% else %}
-public {{ options.modelType }} {{ type }}: {% if parent %}{{ parent.type }}{% else %}APIModel{% endif %} {
+public {{ options.modelType }} {{ type }}: {% if parent %}{{ parent.type }}{% else %}{{ options.modelProtocol }}{% endif %} {
     {% for enum in enums %}
     {% if not enum.isGlobal %}
 

--- a/Templates/Swift/Includes/Model.stencil
+++ b/Templates/Swift/Includes/Model.stencil
@@ -8,7 +8,7 @@ public typealias {{ type }} = {{ aliasType }}
 {% elif additionalPropertiesType and allProperties.count == 0 %}
 public typealias {{ type }} = [String: {{ additionalPropertiesType }}]
 {% else %}
-public {{ options.modelType }} {{ type }}: {% if parent %}{{ parent.type }}{% else %}Codable, Equatable{% endif %} {
+public {{ options.modelType }} {{ type }}: {% if parent %}{{ parent.type }}{% else %}APIModel{% endif %} {
     {% for enum in enums %}
     {% if not enum.isGlobal %}
 

--- a/Templates/Swift/Sources/Coding.swift
+++ b/Templates/Swift/Sources/Coding.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public protocol APIModel: Codable, Equatable { }
+public protocol {{ options.modelProtocol }}: Codable, Equatable { }
 
 public typealias ID = UUID
 

--- a/Templates/Swift/Sources/Coding.swift
+++ b/Templates/Swift/Sources/Coding.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 
+public protocol APIModel: Codable, Equatable { }
+
 public typealias ID = UUID
 
 public protocol ResponseDecoder {

--- a/Templates/Swift/template.yml
+++ b/Templates/Swift/template.yml
@@ -9,6 +9,7 @@ options:
   modelSuffix: null # applied to model classes
   modelType: class # can be struct or class
   modelInheritance: true # must be false for struct modelType
+  modelProtocol: APIModel # the protocol all models conform to
   modelNames: # override model type names
     CreatePaymentRequest: CreatePaymentRequestModel
     DeclinePaymentRequest: DeclinePaymentRequestModel


### PR DESCRIPTION
Each model now conforms to `APIModel`
```swift
public protocol APIModel: Codable, Equatable { }
```

This can be customized in the template options via `modelProtocol`