### PR TITLE
Use SwiftStencilKit

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "891a3fec2699fc43aed18b7649950677c0152a22",
-          "version": "0.8.0"
+          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
+          "version": "0.9.2"
         }
       },
       {
@@ -33,17 +33,26 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "e46b75cf03ad5e563b4b0a5068d3d6f04d77d80b",
-          "version": "0.7.2"
+          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
+          "version": "0.9.0"
         }
       },
       {
         "package": "Stencil",
-        "repositoryURL": "https://github.com/yonaskolb/Stencil.git",
+        "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "daf4e41549a534904376794e899ca6aecaf4ff83",
-          "version": "0.9.3"
+          "revision": "0e9a78d6584e3812cd9c09494d5c7b483e8f533c",
+          "version": "0.13.1"
+        }
+      },
+      {
+        "package": "StencilSwiftKit",
+        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
+        "state": {
+          "branch": null,
+          "revision": "dbf02bd6afe71b65ead2bd250aaf974abc688094",
+          "version": "2.7.2"
         }
       },
       {
@@ -51,8 +60,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "37f4a7f863f6fe76ce44fc0023f331eea0089beb",
-          "version": "5.2.0"
+          "revision": "5318c37d3cacc8780f50b87a8840a6774320ebdf",
+          "version": "5.2.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,12 @@ let package = Package(
         .library(name: "Swagger", targets: ["Swagger"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/kylef/PathKit.git", from: "0.8.0"),
+        .package(url: "https://github.com/kylef/PathKit.git", from: "0.9.0"),
         .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.0.0"),
-        .package(url: "https://github.com/yonaskolb/Stencil.git", from: "0.9.0"),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.7.2"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "1.0.0"),
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "3.3.0"),
-        .package(url: "https://github.com/kylef/Spectre.git", from: "0.7.0"),
+        .package(url: "https://github.com/kylef/Spectre.git", from: "0.9.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.1.0"),
     ],
     targets: [
@@ -28,7 +28,7 @@ let package = Package(
           "Swagger",
           "JSONUtilities",
           "PathKit",
-          "Stencil",
+          "StencilSwiftKit",
         ]),
         .target(name: "Swagger", dependencies: [
           "JSONUtilities",

--- a/Sources/SwagGenKit/Generator.swift
+++ b/Sources/SwagGenKit/Generator.swift
@@ -2,6 +2,7 @@ import Foundation
 import JSONUtilities
 import PathKit
 import Stencil
+import StencilSwiftKit
 
 public class Generator {
 
@@ -21,7 +22,12 @@ public class Generator {
         filterExtension.registerFilter("lowerCamelCase") { ($0 as? String)?.lowerCamelCased() ?? $0 }
         filterExtension.registerFilter("upperCamelCase") { ($0 as? String)?.upperCamelCased() ?? $0 }
 
-        environment = Environment(loader: FileSystemLoader(paths: [templateConfig.basePath]), extensions: [filterExtension])
+        let stencilSwiftKitExtension = Extension()
+        stencilSwiftKitExtension.registerStencilSwiftExtensions()
+
+        environment = Environment(loader: FileSystemLoader(paths: [templateConfig.basePath]),
+                                  extensions: [filterExtension, stencilSwiftKitExtension],
+                                  templateClass: SwagGenStencilTemplate.self)
     }
 
     public enum Clean: String {

--- a/Sources/SwagGenKit/SwagGenStencilTemplate.swift
+++ b/Sources/SwagGenKit/SwagGenStencilTemplate.swift
@@ -1,0 +1,34 @@
+//
+//  SwagGenStencilTemplate.swift
+//  SwagGenKit
+//
+//  Created by Yonas Kolb on 20/2/19.
+//
+
+import Foundation
+import Stencil
+
+open class SwagGenStencilTemplate: Template {
+
+    let replacementString = "akdjh4rhjdfgkv4nvdfdfg"
+
+    public required init(templateString: String, environment: Environment? = nil, name: String? = nil) {
+        let templateStringWithMarkedNewlines = templateString
+            .replacingOccurrences(of: "\n([ \t]*)\n", with: "\n$1\(replacementString)\n", options: .regularExpression)
+            .replacingOccurrences(of: "\n([ \t]*)\n", with: "\n$1\(replacementString)\n", options: .regularExpression)
+        super.init(templateString: templateStringWithMarkedNewlines, environment: environment, name: name)
+    }
+
+    // swiftlint:disable:next discouraged_optional_collection
+    override open func render(_ dictionary: [String: Any]? = nil) throws -> String {
+        return try removeExtraLines(from: super.render(dictionary))
+    }
+
+    // Workaround until Stencil fixes https://github.com/stencilproject/Stencil/issues/22
+    private func removeExtraLines(from string: String) -> String {
+        return string
+            .replacingOccurrences(of: "\\n([ \\t]*\\n)+", with: "\n", options: .regularExpression)
+            .replacingOccurrences(of: "\n([ \t]*)\(replacementString)\n", with: "\n\n", options: .regularExpression)
+            .replacingOccurrences(of: "\n([ \t]*)\(replacementString)\n", with: "\n\n", options: .regularExpression)
+    }
+}

--- a/Specs/Petstore/generated/Swift/Cartfile
+++ b/Specs/Petstore/generated/Swift/Cartfile
@@ -1,2 +1,3 @@
+
 github "Alamofire/Alamofire" ~> 4.7.2
 github "antitypical/Result" ~> 4.0.0

--- a/Specs/Petstore/generated/Swift/Sources/RequestBehaviour.swift
+++ b/Specs/Petstore/generated/Swift/Sources/RequestBehaviour.swift
@@ -115,7 +115,6 @@ struct RequestBehaviourGroup {
     }
 }
 
-
 //MARK: Type erased Requests and Responses
 
 public typealias AnyResponse = APIResponse<AnyResponseValue>

--- a/Specs/PetstoreTest/generated/Swift/Cartfile
+++ b/Specs/PetstoreTest/generated/Swift/Cartfile
@@ -1,2 +1,3 @@
+
 github "Alamofire/Alamofire" ~> 4.7.2
 github "antitypical/Result" ~> 4.0.0

--- a/Specs/PetstoreTest/generated/Swift/Sources/RequestBehaviour.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/RequestBehaviour.swift
@@ -115,7 +115,6 @@ struct RequestBehaviourGroup {
     }
 }
 
-
 //MARK: Type erased Requests and Responses
 
 public typealias AnyResponse = APIResponse<AnyResponseValue>

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEndpointParameters.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEndpointParameters.swift
@@ -12,7 +12,6 @@ extension PetstoreTest.Fake {
 假端點
 偽のエンドポイント
 가짜 엔드 포인트
-
     */
     public enum TestEndpointParameters {
 

--- a/Specs/Rocket/generated/Swift/Cartfile
+++ b/Specs/Rocket/generated/Swift/Cartfile
@@ -1,2 +1,3 @@
+
 github "Alamofire/Alamofire" ~> 4.7.2
 github "antitypical/Result" ~> 4.0.0

--- a/Specs/Rocket/generated/Swift/Rocket.podspec
+++ b/Specs/Rocket/generated/Swift/Rocket.podspec
@@ -4,7 +4,6 @@ Pod::Spec.new do |s|
     s.authors = 'Yonas Kolb'
     s.summary = 'An Orchestration Layer that takes ISL services and packages them in a more targeted way for front-end applications.
 This in turn makes client integration easier and reduces the complexity and size of front-end applications.
-
 Rocket is also customisable - allowing UI engineers to ‘remix’ the existing back-end services into something that
 best suits the application they are developing.
 '

--- a/Specs/Rocket/generated/Swift/Sources/API.swift
+++ b/Specs/Rocket/generated/Swift/Sources/API.swift
@@ -7,7 +7,6 @@ import Foundation
 
 /** An Orchestration Layer that takes ISL services and packages them in a more targeted way for front-end applications.
 This in turn makes client integration easier and reduces the complexity and size of front-end applications.
-
 Rocket is also customisable - allowing UI engineers to ‘remix’ the existing back-end services into something that
 best suits the application they are developing.
  */

--- a/Specs/Rocket/generated/Swift/Sources/Enums/FeatureFlags.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Enums/FeatureFlags.swift
@@ -4,19 +4,14 @@
 //
 
 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
 public enum FeatureFlags: String, Codable {

--- a/Specs/Rocket/generated/Swift/Sources/Models/Account.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Account.swift
@@ -26,7 +26,6 @@ public class Account: APIModel {
     public var primaryProfileId: String
 
     /** The active subscription code for an account.
-
 The value of this should be passed to any endpoints accepting a `sub` query parameter.
  */
     public var subscriptionCode: String
@@ -49,9 +48,7 @@ The value of this should be passed to any endpoints accepting a `sub` query para
     /** The classification rating defining the minimum rating level a user should be
 forced to enter the account pin code for playback. Anything at this rating
 level or above will require the pin for playback.
-
 e.g. AUOFLC-MA15+
-
 If you want to disable this guard pass an empty string or `null`.
  */
     public var minRatingPlaybackGuard: String?

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccountDevices.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccountDevices.swift
@@ -12,18 +12,14 @@ public class AccountDevices: APIModel {
 
     /** The maximum number of playback devices that can be registered
 under an account at a single time.
-
 If there is no maximum defined this value will be `-1`.
  */
     public var maxRegistered: Int
 
     /** Defines the start and end date of the current deregistration window along with calculated limits.
-
 If undefined then there are no deregistration limits for a period.
-
 For example given a deregistration period of 30 days, this sliding window will start on the
 oldest deregistration of the last 30 days, and end 30 days from that deregistration date.
-
 In this window there is a limit on how many devices can be deregistered in 30 days.
 If exceeded then no more devices can be deregistered unless the oldest deregistration drops
 off the 30 day window.
@@ -31,16 +27,12 @@ off the 30 day window.
     public var deregistrationWindow: DeviceRegistrationWindow?
 
     /** Defines the start and end date of the current registration window along with calculated limits.
-
 If undefined then there are no registration limits for a period.
-
 For example given a registration period of 30 days, this sliding window will start on the
 oldest registration of the last 30 days, and end 30 days from that registration date.
-
 In this window there is a limit on how many devices can be registered in 30 days.
 If exceeded then no more devices can be registered unless one is deregistered or the
 oldest registration drops off the 30 day window.
-
 Deregistration also has potential limits which may prevent a device being deregistered.
 In this case the user must wait until the oldest deregistered device is more than 30
 days old.

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccountTokenRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccountTokenRequest.swift
@@ -28,7 +28,6 @@ public class AccountTokenRequest: APIModel {
     along with the token(s). This is only really intended for web based clients which
     need to pass the cookies to a server to render a page based on the users
     content filters, e.g subscription code.
-
     If type `Session` the cookie will be session based.
     If type `Persistent` the cookie will have a medium term lifespan.
     If undefined no cookies will be set.
@@ -55,7 +54,6 @@ For each scope listed an Account and Profile token of that scope will be returne
 along with the token(s). This is only really intended for web based clients which
 need to pass the cookies to a server to render a page based on the users
 content filters, e.g subscription code.
-
 If type `Session` the cookie will be session based.
 If type `Persistent` the cookie will have a medium term lifespan.
 If undefined no cookies will be set.
@@ -63,13 +61,11 @@ If undefined no cookies will be set.
     public var cookieType: CookieType?
 
     /** The password associated with the account.
-
 Either a pin or password should be supplied. If both are supplied the password will take precedence.
  */
     public var password: String?
 
     /** The pin associated with the account.
-
 Either a pin or password should be supplied. If both are supplied the password will take precedence.
  */
     public var pin: String?

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccountUpdateRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccountUpdateRequest.swift
@@ -19,9 +19,7 @@ public class AccountUpdateRequest: APIModel {
     /** The classification rating defining the minimum rating level a user should be
 forced to enter the account pin code for playback. Anything at this rating
 level or above will require the pin for playback.
-
 e.g. AUOFLC-MA15+
-
 If you want to disable this guard pass an empty string or `null`.
  */
     public var minRatingPlaybackGuard: String?

--- a/Specs/Rocket/generated/Swift/Sources/Models/DeviceRegistrationWindow.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/DeviceRegistrationWindow.swift
@@ -17,16 +17,13 @@ public class DeviceRegistrationWindow: APIModel {
     public var remaining: Int
 
     /** The start date of the current period.
-
 This is based on the earliest device de/registrations in the past N days, where
 N is defined by `periodDays`.
-
 If no device has been de/registered then start date will be from the current date.
  */
     public var startDate: DateTime
 
     /** The end date of the current period.
-
 This is based on the value of `startDate` plus the number of days defined by  `periodDays`.
  */
     public var endDate: DateTime

--- a/Specs/Rocket/generated/Swift/Sources/Models/ItemDetail.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ItemDetail.swift
@@ -17,7 +17,6 @@ public class ItemDetail: ItemSummary {
     public var credits: [Credit]?
 
     /** An ordered list of custom name-value-pair item metadata.
-
 Usually displayed on an item detail page.
  */
     public var customMetadata: [ItemCustomMetadata]?

--- a/Specs/Rocket/generated/Swift/Sources/Models/NavContent.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/NavContent.swift
@@ -8,7 +8,6 @@ import Foundation
 public class NavContent: APIModel {
 
     /** The image type to target when rendering items of the list.
-
 e.g wallpaper, poster, hero3x1, logo.
  */
     public var imageType: String?

--- a/Specs/Rocket/generated/Swift/Sources/Models/NavEntry.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/NavEntry.swift
@@ -17,7 +17,6 @@ public class NavEntry: APIModel {
     public var customFields: [String: Any]?
 
     /** True if this is a featured menu item.
-
 Featured menu items may have a more prominent presentation than others in the navigation.
  */
     public var featured: Bool?

--- a/Specs/Rocket/generated/Swift/Sources/Models/Page.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Page.swift
@@ -14,20 +14,16 @@ public class Page: PageSummary {
     public var customFields: [String: Any]?
 
     /** When the page represents the detail of an item this property will contain the item detail.
-
 For clients consuming an item detail page, any page row entry of type `ItemDetailEntry`
 should look to obtain its data from the contents of this property.
-
 *Note that you have to be using feature flag `idp` to enable this
 on item detail pages. See `feature-flags.md` for further details.*
  */
     public var item: ItemDetail?
 
     /** When the page represents the detail of a List this property will contain the list in question.
-
 For clients consuming a list detail page, any page row entry of type `ListDetailEntry`
 should look to obtain its data from the contents of this property.
-
 *Note that you have to be using feature flag `ldp` to enable this
 on list detail pages. See `feature-flags.md` for further details.*
  */

--- a/Specs/Rocket/generated/Swift/Sources/Models/PageEntry.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PageEntry.swift
@@ -52,7 +52,6 @@ public class PageEntry: APIModel {
     public var customFields: [String: Any]?
 
     /** The images for the page entry if any.
-
 For example the images of an `ImageEntry`.
  */
     public var images: [String: URL]?

--- a/Specs/Rocket/generated/Swift/Sources/Models/PageSummary.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PageSummary.swift
@@ -20,7 +20,6 @@ public class PageSummary: APIModel {
     public var template: String
 
     /** True if this page is static and doesn't have any dynamic content to load.
-
 Static pages don't need to go back to the page endpoint to load page content
 instead the page summary loaded with the sitemap should be enough to determine
 the page template type and render based on this.
@@ -28,7 +27,6 @@ the page template type and render based on this.
     public var isStatic: Bool
 
     /** True if this page is a system page type.
-
 **DEPRECATED** This property doesn't have any real use in client applications
 anymore so shouldn't be used. It especially shouldn't be used to determine if
 a page is static or not. Use the `isStatic` property instead.

--- a/Specs/Rocket/generated/Swift/Sources/Models/Pagination.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Pagination.swift
@@ -8,7 +8,6 @@ import Foundation
 public class Pagination: APIModel {
 
     /** The total number of pages available given the current page size.
-
 A value of -1 indicates that the total has not yet been determined. This may
 arise when embedding secure list pagination info in a page which must be cached
 by a CDN. For example a Bookmarks list.
@@ -16,7 +15,6 @@ by a CDN. For example a Bookmarks list.
     public var total: Int
 
     /** The current page number.
-
 A value of 0 indicates that the fist page has not yet been loaded. This is
 useful when wanting to return the paging metadata to indicate how to
 load in the first page.
@@ -24,7 +22,6 @@ load in the first page.
     public var page: Int
 
     /** The authorization requirements to load a page of items.
-
 This will only be present on lists which are protected by some form
 of authorization token e.g. Bookmarks, Watched, Entitlements.
  */
@@ -34,7 +31,6 @@ of authorization token e.g. Bookmarks, Watched, Entitlements.
     public var next: String?
 
     /** Any active list sort and filter options.
-
 If an option has a default value then it won't be defined.
  */
     public var options: PaginationOptions?
@@ -43,7 +39,6 @@ If an option has a default value then it won't be defined.
     public var previous: String?
 
     /** The current page size.
-
 A value of -1 indicates that the size has not yet been determined. This may
 arise when embedding secure list pagination info in a page which must be cached
 by a CDN. For example a Bookmarks list.

--- a/Specs/Rocket/generated/Swift/Sources/Models/ProfileCreationRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ProfileCreationRequest.swift
@@ -11,7 +11,6 @@ public class ProfileCreationRequest: APIModel {
     public var name: String
 
     /** Whether an account pin is required to enter the profile.
-
 If no account pin is defined this has no impact.
  */
     public var pinEnabled: Bool?

--- a/Specs/Rocket/generated/Swift/Sources/Models/ProfileSummary.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ProfileSummary.swift
@@ -14,7 +14,6 @@ public class ProfileSummary: APIModel {
     public var name: String
 
     /** Whether the profile is active or not.
-
 **DEPRECATED** - Always true. Inactive profiles are no longer returned.
  */
     public var isActive: Bool
@@ -26,7 +25,6 @@ public class ProfileSummary: APIModel {
     public var purchaseEnabled: Bool
 
     /** Whether the profile has opted in or out of marketing material.
-
 **DEPRECATED** - Marketing material is no longer tied to profiles, only account. See `Account.marketingEnabled`.
  */
     public var marketingEnabled: Bool
@@ -35,7 +33,6 @@ public class ProfileSummary: APIModel {
     public var segments: [String]
 
     /** The maximum rating (inclusive) of content to return in feeds.
-
 **DEPRECATED** - It's no longer recommended filtering content globally as apps can end up
 with pages without content, even the homepage. Instead using features like segmentation
 tags to target demographics like kids means content curation can be more thought out.
@@ -43,7 +40,6 @@ tags to target demographics like kids means content curation can be more thought
     public var maxRatingContentFilter: ClassificationSummary?
 
     /** The minumum rating (inclusive) of content where an account pin should be presented before entring playback.
-
 **DEPRECATED** - The playback guard is now defined at the account level, where an account
 pin also exists. This is then applied across all profiles.
  */

--- a/Specs/Rocket/generated/Swift/Sources/Models/ProfileUpdateRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ProfileUpdateRequest.swift
@@ -11,7 +11,6 @@ public class ProfileUpdateRequest: APIModel {
     public var name: String?
 
     /** Whether an account pin is required to enter the profile.
-
 If no account pin is defined this has no impact.
  */
     public var pinEnabled: Bool?

--- a/Specs/Rocket/generated/Swift/Sources/Models/SearchResults.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/SearchResults.swift
@@ -14,13 +14,11 @@ public class SearchResults: APIModel {
     public var total: Int
 
     /** The list of all items relevant to the search term.
-
 If this is present then the `movies` and `tv` lists won't be.
  */
     public var items: ItemList?
 
     /** The list of movie items relevant to the search term.
-
 If this is present then the `items` list won't be.
  */
     public var movies: ItemList?
@@ -29,7 +27,6 @@ If this is present then the `items` list won't be.
     public var people: [Person]?
 
     /** The list of tv items (shows + programs) relevant to the search term.
-
 If this is present then the `items` list won't be.
  */
     public var tv: ItemList?

--- a/Specs/Rocket/generated/Swift/Sources/Models/Subscription.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Subscription.swift
@@ -40,7 +40,6 @@ public class Subscription: APIModel {
     public var status: Status
 
     /** The end date of a subscription.
-
 Some subscriptions may not have an end date, in which case this
 property will not exist.
  */

--- a/Specs/Rocket/generated/Swift/Sources/Models/TokenRefreshRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/TokenRefreshRequest.swift
@@ -11,7 +11,6 @@ public class TokenRefreshRequest: APIModel {
     along with the token(s). This is only really intended for web based clients which
     need to pass the cookies to a server to render a page based on the users
     content filters, e.g subscription code.
-
     If type `Session` the cookie will be session based.
     If type `Persistent` the cookie will have a medium term lifespan.
     If undefined no cookies will be set.
@@ -33,7 +32,6 @@ public class TokenRefreshRequest: APIModel {
 along with the token(s). This is only really intended for web based clients which
 need to pass the cookies to a server to render a page based on the users
 content filters, e.g subscription code.
-
 If type `Session` the cookie will be session based.
 If type `Persistent` the cookie will have a medium term lifespan.
 If undefined no cookies will be set.

--- a/Specs/Rocket/generated/Swift/Sources/RequestBehaviour.swift
+++ b/Specs/Rocket/generated/Swift/Sources/RequestBehaviour.swift
@@ -115,7 +115,6 @@ struct RequestBehaviourGroup {
     }
 }
 
-
 //MARK: Type erased Requests and Responses
 
 public typealias AnyResponse = APIResponse<AnyResponseValue>

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/DeleteProfileWithId.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/DeleteProfileWithId.swift
@@ -9,9 +9,7 @@ extension Rocket.Account {
 
     /**
     Delete a profile with a specific id under the active account.
-
 Note that you cannot delete the primary profile.
-
     */
     public enum DeleteProfileWithId {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetDevices.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetDevices.swift
@@ -9,9 +9,7 @@ extension Rocket.Account {
 
     /**
     Get all devices registered under this account.
-
 Also includes information around device registration and deregistration limits.
-
     */
     public enum GetDevices {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetEntitlements.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetEntitlements.swift
@@ -9,10 +9,8 @@ extension Rocket.Account {
 
     /**
     Get all entitlements under the account.
-
 This list is returned under the call to get account information so a call here is
 only required when wishing to refresh a local copy of entitlements.
-
     */
     public enum GetEntitlements {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetItemMediaFiles.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetItemMediaFiles.swift
@@ -10,30 +10,23 @@ extension Rocket.Account {
     /**
     Get the video files associated with an item given maximum resolution, device type
 and one or more delivery types.
-
 This endpoint accepts an Account Catalog token, however if when requesting
 playback files you receive an *403 status code with error code 1* then the file
 you're requesting is classification restricted. This means you should switch
 to target the `/account/items/{id}/videos-guarded` endpoint, passing it an Account
 Playback token. If not already obtained, this token can be requested via the
 `/authorization` endpoint with an account level pin.
-
 For convenience you may also access free / public files through this endpoint
 instead of the /items/{id}/videos endpoint, when authenticated.
-
 Returns an array of video file objects which each include a url to a video.
-
 The first entry in the array contains what is predicted to be the best match.
 The remainder of the entries, if any, may contain resolutions below what was
 requests. For example if you request HD-720 the response may also contain
 SD entries.
-
 If you specify multiple delivery types, then the response array will insert
 types in the order you specify them in the query. For example `stream,progressive`
 would return an array with 0 or more stream files followed by 0 or more progressive files.
-
 If no files are found a 404 is returned.
-
     */
     public enum GetItemMediaFiles {
 
@@ -62,19 +55,14 @@ If no files are found a 404 is returned.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetItemMediaFilesGuarded.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/GetItemMediaFilesGuarded.swift
@@ -10,25 +10,19 @@ extension Rocket.Account {
     /**
     Get the video files associated with an item given maximum resolution, device type
 and one or more delivery types.
-
 This endpoint is identical to the `/account/items/{id}/videos` however it expects
 an Account Playback token. This token, and in association this endpoint, is specifically
 for use when playback files are classification restricted and require an account
 level pin to access them.
-
 Returns an array of video file objects which each include a url to a video.
-
 The first entry in the array contains what is predicted to be the best match.
 The remainder of the entries, if any, may contain resolutions below what was
 requests. For example if you request HD-720 the response may also contain
 SD entries.
-
 If you specify multiple delivery types, then the response array will insert
 types in the order you specify them in the query. For example `stream,progressive`
 would return an array with 0 or more stream files followed by 0 or more progressive files.
-
 If no files are found a 404 is returned.
-
     */
     public enum GetItemMediaFilesGuarded {
 
@@ -57,19 +51,14 @@ If no files are found a 404 is returned.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/RegisterDevice.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/RegisterDevice.swift
@@ -9,9 +9,7 @@ extension Rocket.Account {
 
     /**
     Register a playback device under an account.
-
 If a device with the same id already exists a `409` conflict will be returned.
-
     */
     public enum RegisterDevice {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/RequestEmailVerification.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/RequestEmailVerification.swift
@@ -9,17 +9,13 @@ extension Rocket.Account {
 
     /**
     Request that the email address tied to an account be verified.
-
 This will send a verification email to the email address of the primary profile containing
 a link which, once clicked, completes the verification process via the /verify-email endpoint.
-
 Note that when an account is created this email is sent automatically so there's no need
 to call this directly.
-
 If the user doesn't click the link before it expires then this endpoint can be called
 to request a new verification email. In the future it may also be used if we add support
 for changing an account email address.
-
     */
     public enum RequestEmailVerification {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateAccount.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateAccount.swift
@@ -9,9 +9,7 @@ extension Rocket.Account {
 
     /**
     Update the details of an account.
-
 This supports partial updates so you can send just the properties you wish to update.
-
     */
     public enum UpdateAccount {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateProfileWithId.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateProfileWithId.swift
@@ -9,9 +9,7 @@ extension Rocket.Account {
 
     /**
     Update the summary of a profile with a specific id under the active account.
-
 This supports partial updates so you can send just the properties you wish to update.
-
     */
     public enum UpdateProfileWithId {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/App/GetAppConfig.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/App/GetAppConfig.swift
@@ -9,13 +9,10 @@ extension Rocket.App {
 
     /**
     Get the global configuration for an application. Should be called during app statup.
-
 This includes things like device and playback rules, classifications,
 sitemap and subscriptions.
-
 You have the option to select specific configuration objects using the 'include'
 parameter, or if unspecified, getting all configuration.
-
     */
     public enum GetAppConfig {
 
@@ -61,19 +58,14 @@ If none specified then all configuration is returned.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/App/GetPage.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/App/GetPage.swift
@@ -9,31 +9,24 @@ extension Rocket.App {
 
     /**
     Returns a page with the specified id.
-
 If targeting the search page you must url encode the search term as a parameter
 using the `q` key. For example if your browser path looks like `/search?q=the`
 then what you pass to this endpoint would look like `/page?path=/search%3Fq%3Dthe`.
-
     */
     public enum GetPage {
 
         public static let service = APIService<Response>(id: "getPage", tag: "app", method: "GET", path: "/page", hasBody: false)
 
         /** Only relevant when loading item detail pages as these embed a detailed item in the main page entry.
-
         If no value is specified no item dependencies are expanded.
-
         If 'children' is specified then the list of any direct children will be expanded. For example
         seasons of a show or episodes of a season.
-
         If 'all' is specified then the parent chain will be expanded along with any child list at each level.
         For example if an episode is specified then its season will be expanded and that season's episode list.
         The season will have its show expanded and the show will have its season list expanded.
-
         The 'all' options is useful when you deep link into a show/season/episode for the first time as
         it provides full context for navigating around the show page. Subsequent navigation around
         children of the show should only need to request expand of children.
-
         If an expand is specified which is not relevant to the item type, it will be ignored.
          */
         public enum ItemDetailExpand: String, Codable {
@@ -47,10 +40,8 @@ then what you pass to this endpoint would look like `/page?path=/search%3Fq%3Dth
         }
 
         /** Only relevant when loading show detail pages as these embed a detailed item in the main page entry.
-
         Given a targeted show page, it can be useful to get the details of a child season. This option
         provides a means to return the `first` or `latest` season of a show embedded in the page.
-
         The `expand` parameter also works here so for example you could land on a show page and request the
         `item_detail_select_season=latest` along with `item_detail_expand=all`. This would then return the
         detail of the latest season with its list of child episode summaries, and also expand
@@ -67,7 +58,6 @@ then what you pass to this endpoint would look like `/page?path=/search%3Fq%3Dth
         }
 
         /** Only relevant to page entries of type `TextEntry`.
-
         Converts the value of a text page entry to the specified format.
          */
         public enum TextEntryFormat: String, Codable {
@@ -91,7 +81,6 @@ then what you pass to this endpoint would look like `/page?path=/search%3Fq%3Dth
                 public var listPageSize: Int?
 
                 /** The number of items to load when prefetching a continuous scroll list entry in a page.
-
 By default any list page entry with template pattern `/^CS\d+$/` will
 be considered a continuous scroll list.
  */
@@ -101,29 +90,22 @@ be considered a continuous scroll list.
                 public var maxListPrefetch: Int?
 
                 /** Only relevant when loading item detail pages as these embed a detailed item in the main page entry.
-
 If no value is specified no item dependencies are expanded.
-
 If 'children' is specified then the list of any direct children will be expanded. For example
 seasons of a show or episodes of a season.
-
 If 'all' is specified then the parent chain will be expanded along with any child list at each level.
 For example if an episode is specified then its season will be expanded and that season's episode list.
 The season will have its show expanded and the show will have its season list expanded.
-
 The 'all' options is useful when you deep link into a show/season/episode for the first time as
 it provides full context for navigating around the show page. Subsequent navigation around
 children of the show should only need to request expand of children.
-
 If an expand is specified which is not relevant to the item type, it will be ignored.
  */
                 public var itemDetailExpand: ItemDetailExpand?
 
                 /** Only relevant when loading show detail pages as these embed a detailed item in the main page entry.
-
 Given a targeted show page, it can be useful to get the details of a child season. This option
 provides a means to return the `first` or `latest` season of a show embedded in the page.
-
 The `expand` parameter also works here so for example you could land on a show page and request the
 `item_detail_select_season=latest` along with `item_detail_expand=all`. This would then return the
 detail of the latest season with its list of child episode summaries, and also expand
@@ -132,7 +114,6 @@ the detail of the show with its list of seasons summaries.
                 public var itemDetailSelectSeason: ItemDetailSelectSeason?
 
                 /** Only relevant to page entries of type `TextEntry`.
-
 Converts the value of a text page entry to the specified format.
  */
                 public var textEntryFormat: TextEntryFormat?
@@ -150,19 +131,14 @@ Converts the value of a text page entry to the specified format.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetAccountToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetAccountToken.swift
@@ -9,28 +9,21 @@ extension Rocket.Authorization {
 
     /**
     Request one or more `Account` level authorization tokens each with a chosen scope.
-
 Tokens are used to access restricted service endpoints. These restricted endpoints
 will require a specific token type (e.g Account) with a specific scope (e.g. Catalog)
 before access is granted.
-
 For convenience, where a Profile level token with the same scope exists it will also be returned.
 This removes the need to prompt a user for a password on login followed directly with a
 pin prompt for a profile token of the same scope.
-
 Where an Account level pin is supported, some tokens may be returned from this endpoint
 by providing this pin instead of a password. For example the `Playback` scoped Account
 token is one such type.
-
 Any token which is returnable with an Account pin will also be returnable with the
 Account password. On the inverse, not all scoped tokens that are returnable via password
 will be returnable via the pin. For example when you log in you receive an Account Catalog
 token. This is not obtainable from an Account pin, only password.
-
 If both a pin and password are supplied only the password will be used.
-
 If neither a pin or password are supplied an http 400 error will be returned.
-
     */
     public enum GetAccountToken {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetProfileToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetProfileToken.swift
@@ -9,11 +9,9 @@ extension Rocket.Authorization {
 
     /**
     Request one or more `Profile` level authorization tokens each with a chosen scope.
-
 Tokens are used to access restricted service endpoints. These restriced endpoints
 will require a specific token type (e.g Profile) with a specific scope (e.g. Catalog)
 before access is granted.
-
     */
     public enum GetProfileToken {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/SignOut.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/SignOut.swift
@@ -10,7 +10,6 @@ extension Rocket.Authorization {
     /**
     When a user signs out of an application we need to clear some
 basic cookies we assigned them during token authorization.
-
     */
     public enum SignOut {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItem.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItem.swift
@@ -15,18 +15,14 @@ extension Rocket.Content {
         public static let service = APIService<Response>(id: "getItem", tag: "content", method: "GET", path: "/items/{id}", hasBody: false)
 
         /** If no value is specified no dependencies are expanded.
-
         If 'children' is specified then the list of any direct children will be expanded. For example
         seasons of a show or episodes of a season.
-
         If 'all' is specified then the parent chain will be expanded along with any child list at each level.
         For example if an episode is specified then its season will be expanded and that season's episode list.
         The season will have its show expanded and the show will have its season list expanded.
-
         The 'all' options is useful when you deep link into a show/season/episode for the first time as
         it provides full context for navigating around the show page. Subsequent navigation around
         children of the show should only need to request expand of children.
-
         If an expand is specified which is not relevant to the item type, it will be ignored.
          */
         public enum Expand: String, Codable {
@@ -41,11 +37,9 @@ extension Rocket.Content {
 
         /** Given a provided show id, it can be useful to get the details of a child season. This option
         provides a means to return the `first` or `latest` season of a show given the show id.
-
         The `expand` parameter also works here so for example you could land on a show page and request the
         latest season along with `expand=all`. This would then return the detail of the latest season with
         its list of child episode summaries, and also expand the detail of the show with its list of seasons summaries.
-
         Note the `id` parameter must be a show id for this parameter to work correctly.
          */
         public enum SelectSeason: String, Codable {
@@ -63,7 +57,6 @@ extension Rocket.Content {
             public struct Options {
 
                 /** The identifier of the item to load.
-
 The custom identifier of an item can be used here if the `use_custom_id` parameter is true.
  */
                 public var id: String
@@ -72,29 +65,23 @@ The custom identifier of an item can be used here if the `use_custom_id` paramet
                 public var maxRating: String?
 
                 /** If no value is specified no dependencies are expanded.
-
 If 'children' is specified then the list of any direct children will be expanded. For example
 seasons of a show or episodes of a season.
-
 If 'all' is specified then the parent chain will be expanded along with any child list at each level.
 For example if an episode is specified then its season will be expanded and that season's episode list.
 The season will have its show expanded and the show will have its season list expanded.
-
 The 'all' options is useful when you deep link into a show/season/episode for the first time as
 it provides full context for navigating around the show page. Subsequent navigation around
 children of the show should only need to request expand of children.
-
 If an expand is specified which is not relevant to the item type, it will be ignored.
  */
                 public var expand: Expand?
 
                 /** Given a provided show id, it can be useful to get the details of a child season. This option
 provides a means to return the `first` or `latest` season of a show given the show id.
-
 The `expand` parameter also works here so for example you could land on a show page and request the
 latest season along with `expand=all`. This would then return the detail of the latest season with
 its list of child episode summaries, and also expand the detail of the show with its list of seasons summaries.
-
 Note the `id` parameter must be a show id for this parameter to work correctly.
  */
                 public var selectSeason: SelectSeason?
@@ -112,19 +99,14 @@ Note the `id` parameter must be a show id for this parameter to work correctly.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItemChildrenList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItemChildrenList.swift
@@ -9,13 +9,9 @@ extension Rocket.Content {
 
     /**
     Returns the List of child summary items under an item.
-
 If the item is a Season then the children will be episodes and ordered by episode number.
-
 If the item is a Show then the children will be Seasons and ordered by season number.
-
 Returns 404 if no children found.
-
     */
     public enum GetItemChildrenList {
 
@@ -50,19 +46,14 @@ Returns 404 if no children found.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItemRelatedList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItemRelatedList.swift
@@ -9,9 +9,7 @@ extension Rocket.Content {
 
     /**
     Returns the list of items related to the parent item.
-
 Note for now, due to the size of the list being unknown, only a single page will be returned.
-
     */
     public enum GetItemRelatedList {
 
@@ -43,19 +41,14 @@ Note for now, due to the size of the list being unknown, only a single page will
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetList.swift
@@ -52,19 +52,14 @@ extension Rocket.Content {
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetLists.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetLists.swift
@@ -19,17 +19,11 @@ extension Rocket.Content {
             public struct Options {
 
                 /** A comma delimited list of item list identifiers.
-
 These can be list ids e.g. `14354,65473,3234`
-
 Or more complex sort/filter queries using pipes e.g.
-
 `14354|max_rating=AUOFLC-E|order=asc|order_by=year-added,65473|page_size=30,3234`
-
 _Note the id must always come first for each encoded list query_
-
 List parameters may be provide without the `param=` prefix e.g. `14354|genre:action`
-
 Only the following options can be present.
   - `order`
   - `order_by`
@@ -65,19 +59,14 @@ Only the following options can be present.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetPlan.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetPlan.swift
@@ -31,19 +31,14 @@ extension Rocket.Content {
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetPublicItemMediaFiles.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetPublicItemMediaFiles.swift
@@ -10,20 +10,15 @@ extension Rocket.Content {
     /**
     Get the free / public video files associated with an item given maximum resolution,
 device type and one or more delivery types.
-
 Returns an array of video file objects which each include a url to a video.
-
 The first entry in the array contains what is predicted to be the best match.
 The remainder of the entries, if any, may contain resolutions below what was
 requests. For example if you request HD-720 the response may also contain
 SD entries.
-
 If you specify multiple delivery types, then the response array will insert
 types in the order you specify them in the query. For example `stream,progressive`
 would return an array with 0 or more stream files followed by 0 or more progressive files.
-
 If no files are found a 404 is returned.
-
     */
     public enum GetPublicItemMediaFiles {
 
@@ -52,19 +47,14 @@ If no files are found a 404 is returned.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetSchedules.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetSchedules.swift
@@ -9,25 +9,20 @@ extension Rocket.Content {
 
     /**
     Returns schedules for a defined set of channels over a requested period.
-
 Schedules are requested in hour blocks and returned grouped by the channel
 they belong to.
-
 For example, to load 12 hours of schedules for channels `4343` and `5234`,
 on 21/2/2017 starting from 08:00.
-
 ```
 channels=4343,5234
 date=2017-02-21
 hour=8
 x=12
 ```
-
 If a channel id is passed which doesn't exist then this endpoint will
 return an empty schedule list for it. If instead we returned 404,
 this would invalidate all other channel schedules in the same request
 which would be unfriendly for clients presenting these channel schedules.
-
     */
     public enum GetSchedules {
 
@@ -41,21 +36,17 @@ which would be unfriendly for clients presenting these channel schedules.
                 public var channels: [String]
 
                 /** The date to target in ISO format, e.g. `2017-05-23`.
-
 The base hour requested will belong to this date.
  */
                 public var date: DateDay
 
                 /** The base hour in the day, defined by the `date` parameter, you wish to load schedules for.
-
 From 0 to 23, where 0 is midnight.
  */
                 public var hour: Int
 
                 /** The number of hours of schedules to load from the base `hour` parameter.
-
 This may be negative or positive depending on whether you want to load past or future schedules.
-
 A value of zero is invalid.
  */
                 public var duration: Int
@@ -70,19 +61,14 @@ A value of zero is invalid.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?
@@ -138,7 +124,6 @@ See the `feature-flags.md` for available flag details.
             public typealias SuccessType = [ItemScheduleList]
 
             /** An array of schedule lists for each channel requested.
-
 The order of the channels will match the order of channel ids passed during the request.
  */
             case status200([ItemScheduleList])

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/Search.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/Search.swift
@@ -16,7 +16,6 @@ extension Rocket.Content {
 
         /** By default people, movies and tv (shows + programs) will be included
         in the search results.
-
         If you don't want all of these types you can specifiy the specific
         includes you care about.
          */
@@ -41,7 +40,6 @@ extension Rocket.Content {
 
                 /** By default people, movies and tv (shows + programs) will be included
 in the search results.
-
 If you don't want all of these types you can specifiy the specific
 includes you care about.
  */
@@ -50,9 +48,7 @@ includes you care about.
                 /** When this option is set, instead of all search result items being returned
 in a single list, they will instead be returned under two lists. One for
 movies and another for tv (shows + programs).
-
 Default is undefined meaning items will be returned in a single list.
-
 The array of `people` results will alway be separate from items.
  */
                 public var group: Bool?
@@ -73,19 +69,14 @@ The array of `people` results will alway be separate from items.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/BookmarkItem.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/BookmarkItem.swift
@@ -9,9 +9,7 @@ extension Rocket.Profile {
 
     /**
     Bookmark an item under the active profile.
-
 Creates one if it doesn't exist, overwrites one if it does.
-
     */
     public enum BookmarkItem {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetBookmarkList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetBookmarkList.swift
@@ -40,19 +40,14 @@ extension Rocket.Profile {
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetRatingsList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetRatingsList.swift
@@ -15,7 +15,6 @@ extension Rocket.Profile {
         public static let service = APIService<Response>(id: "getRatingsList", tag: "profile", method: "GET", path: "/account/profile/ratings/list", hasBody: false, securityRequirement: SecurityRequirement(type: "profileAuth", scope: "Catalog"))
 
         /** What to order by.
-
         Ordering by `date-modified` equates to ordering by the last rated date.
          */
         public enum OrderBy: String, Codable {
@@ -42,7 +41,6 @@ extension Rocket.Profile {
                 public var order: ListOrder?
 
                 /** What to order by.
-
 Ordering by `date-modified` equates to ordering by the last rated date.
  */
                 public var orderBy: OrderBy?
@@ -60,19 +58,14 @@ Ordering by `date-modified` equates to ordering by the last rated date.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetWatchedList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetWatchedList.swift
@@ -15,7 +15,6 @@ extension Rocket.Profile {
         public static let service = APIService<Response>(id: "getWatchedList", tag: "profile", method: "GET", path: "/account/profile/watched/list", hasBody: false, securityRequirement: SecurityRequirement(type: "profileAuth", scope: "Catalog"))
 
         /** What to order by.
-
         Ordering by `date-modified` equates to ordering by the last watched date.
          */
         public enum OrderBy: String, Codable {
@@ -42,7 +41,6 @@ extension Rocket.Profile {
                 public var order: ListOrder?
 
                 /** What to order by.
-
 Ordering by `date-modified` equates to ordering by the last watched date.
  */
                 public var orderBy: OrderBy?
@@ -60,19 +58,14 @@ Ordering by `date-modified` equates to ordering by the last watched date.
                 public var segments: [String]?
 
                 /** The set of opt in feature flags which cause breaking changes to responses.
-
 While Rocket APIs look to avoid breaking changes under the active major version, the formats of responses
 may need to evolve over this time.
-
 These feature flags allow clients to select which response formats they expect and avoid breaking
 clients as these formats evolve under the current major version.
-
 ### Flags
-
 - `all` - Enable all flags. Useful for testing. _Don't use in production_.
 - `idp` - Dynamic item detail pages with schedulable rows.
 - `ldp` - Dynamic list detail pages with schedulable rows.
-
 See the `feature-flags.md` for available flag details.
  */
                 public var ff: [FeatureFlags]?

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/RateItem.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/RateItem.swift
@@ -9,9 +9,7 @@ extension Rocket.Profile {
 
     /**
     Rate an item under the active profile.
-
 Creates one if it doesn't exist, overwrites one if it does.
-
     */
     public enum RateItem {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/SetItemWatchedStatus.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/SetItemWatchedStatus.swift
@@ -9,11 +9,8 @@ extension Rocket.Profile {
 
     /**
     Record the watched playhead position of a video under the active profile.
-
 Can be used later to resume a video from where it was last watched.
-
 Creates one if it doesn't exist, overwrites one if it does.
-
     */
     public enum SetItemWatchedStatus {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Registration/Register.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Registration/Register.swift
@@ -9,18 +9,14 @@ extension Rocket.Registration {
 
     /**
     Register a new user, creating them an account.
-
 Registration, when successful, will return an array of access tokens so the user is
 immediately signed in.
-
 It returns Catalog and Commerce scoped tokens for both Account and Profile.
 The Commerce ones are intended to allow the purchase of a subscription plan
 in the step after registration, without the user being prompted to enter
 their username and password again.
-
 An email will also be sent with a link they need to click to confirm their
 email address. This confirmation is done via the /verify-email endpoint.
-
     */
     public enum Register {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Support/ForgotPassword.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Support/ForgotPassword.swift
@@ -9,16 +9,12 @@ extension Rocket.Support {
 
     /**
     Request the password of an account's primary profile be reset.
-
 Should be called when a user has forgotten their password.
-
 This will send an email with a password reset link to the email address of the
 primary profile of an account.
-
 The link, once clicked, should take the user to the "reset-password" page of the
 website. Here they will enter their new password and submit to the /reset-password
 endpoint here, along with the password reset token provided in the original link.
-
     */
     public enum ForgotPassword {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Support/ResetPassword.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Support/ResetPassword.swift
@@ -12,12 +12,10 @@ extension Rocket.Support {
 email is sent to the email address of the primary profile of the account. This email contains a link
 with a token as query parameter. The link should takes the user to the "reset-password"
 page of the website.
-
 From the reset-password page a user should enter their primary account email address
 and the new password they wish to use. These should then be submitted to this endpoint,
 along with the token from the email link. The token should be provided in the authorization
 header as a bearer token.
-
     */
     public enum ResetPassword {
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Support/VerifyEmail.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Support/VerifyEmail.swift
@@ -10,14 +10,11 @@ extension Rocket.Support {
     /**
     When an account is created an email is sent to the email address of the new account.
 This contains a link, which once clicked, verifies the email address of the account is correct.
-
 The link contains a token as a query parameter which should be passed as the authorization
 bearer token to this endpoint to complete email verification.
-
 The token has en expiry, so if the link is not clicked before it expires, the account holder
 may need to request a new verification email be sent. This can be done via the endpoint
 /account/request-email-verification.
-
     */
     public enum VerifyEmail {
 

--- a/Specs/TBX/generated/Swift/Cartfile
+++ b/Specs/TBX/generated/Swift/Cartfile
@@ -1,2 +1,3 @@
+
 github "Alamofire/Alamofire" ~> 4.7.2
 github "antitypical/Result" ~> 4.0.0

--- a/Specs/TBX/generated/Swift/Sources/RequestBehaviour.swift
+++ b/Specs/TBX/generated/Swift/Sources/RequestBehaviour.swift
@@ -115,7 +115,6 @@ struct RequestBehaviourGroup {
     }
 }
 
-
 //MARK: Type erased Requests and Responses
 
 public typealias AnyResponse = APIResponse<AnyResponseValue>

--- a/Specs/TFL/generated/Swift/Cartfile
+++ b/Specs/TFL/generated/Swift/Cartfile
@@ -1,2 +1,3 @@
+
 github "Alamofire/Alamofire" ~> 4.7.2
 github "antitypical/Result" ~> 4.0.0

--- a/Specs/TFL/generated/Swift/Sources/RequestBehaviour.swift
+++ b/Specs/TFL/generated/Swift/Sources/RequestBehaviour.swift
@@ -115,7 +115,6 @@ struct RequestBehaviourGroup {
     }
 }
 
-
 //MARK: Type erased Requests and Responses
 
 public typealias AnyResponse = APIResponse<AnyResponseValue>

--- a/Specs/TestSpec/generated/Swift/Cartfile
+++ b/Specs/TestSpec/generated/Swift/Cartfile
@@ -1,2 +1,3 @@
+
 github "Alamofire/Alamofire" ~> 4.7.2
 github "antitypical/Result" ~> 4.0.0

--- a/Specs/TestSpec/generated/Swift/Sources/RequestBehaviour.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/RequestBehaviour.swift
@@ -115,7 +115,6 @@ struct RequestBehaviourGroup {
     }
 }
 
-
 //MARK: Type erased Requests and Responses
 
 public typealias AnyResponse = APIResponse<AnyResponseValue>

--- a/Templates/Swift/Includes/Model.stencil
+++ b/Templates/Swift/Includes/Model.stencil
@@ -2,7 +2,7 @@
 /** {{ description }} */
 {% endif %}
 {% if enum %}
-{% include "Includes/Enum.stencil" using enum %}
+{% include "Includes/Enum.stencil" enum %}
 {% elif aliasType %}
 public typealias {{ type }} = {{ aliasType }}
 {% elif additionalPropertiesType and allProperties.count == 0 %}
@@ -12,7 +12,7 @@ public {{ options.modelType }} {{ type }}: {% if parent %}{{ parent.type }}{% el
     {% for enum in enums %}
     {% if not enum.isGlobal %}
 
-    {% include "Includes/Enum.stencil" using enum %}
+    {% filter indent:4 %}{% include "Includes/Enum.stencil" enum %}{% endfilter %}
     {% endif %}
     {% endfor %}
     {% for property in properties %}
@@ -28,7 +28,7 @@ public {{ options.modelType }} {{ type }}: {% if parent %}{{ parent.type }}{% el
     {% endif %}
     {% for schema in schemas %}
 
-    {% include "Includes/Model.stencil" using schema %}
+    {% filter indent:4 %}{% include "Includes/Model.stencil" schema %}{% endfilter %}
     {% endfor %}
 
     public init({% for property in allProperties %}{{ property.name }}: {{ property.optionalType }}{% ifnot property.required %} = nil{% endif %}{% ifnot forloop.last %}, {% endif %}{% endfor %}) {

--- a/Templates/Swift/Sources/Request.swift
+++ b/Templates/Swift/Sources/Request.swift
@@ -23,14 +23,14 @@ extension {{ options.name }}{% if tag %}.{{ options.tagPrefix }}{{ tag|upperCame
         {% for enum in requestEnums %}
         {% if not enum.isGlobal %}
 
-        {% include "Includes/Enum.stencil" using enum %}
+        {% filter indent:8 %}{% include "Includes/Enum.stencil" enum %}{% endfilter %}
         {% endif %}
         {% endfor %}
 
         public final class Request: APIRequest<Response> {
             {% for schema in requestSchemas %}
 
-            {% include "Includes/Model.stencil" using schema %}
+            {% filter indent:12 %}{% include "Includes/Model.stencil" schema %}{% endfilter %}
             {% endfor %}
             {% if nonBodyParams %}
 
@@ -106,12 +106,12 @@ extension {{ options.name }}{% if tag %}.{{ options.tagPrefix }}{{ tag|upperCame
         public enum Response: APIResponseValue, CustomStringConvertible, CustomDebugStringConvertible {
             {% for schema in responseSchemas %}
 
-            {% include "Includes/Model.stencil" using schema %}
+            {% filter indent:12 %}{% include "Includes/Model.stencil" schema %}{% endfilter %}
             {% endfor %}
             {% for enum in responseEnums %}
             {% if not enum.isGlobal %}
 
-            {% include "Includes/Enum.stencil" using enum %}
+            {% filter indent:12 %}{% include "Includes/Enum.stencil" enum %}{% endfilter %}
             {% endif %}
             {% endfor %}
             public typealias SuccessType = {{ successType|default:"Void"}}

--- a/Templates/Swift/Sources/RequestBehaviour.swift
+++ b/Templates/Swift/Sources/RequestBehaviour.swift
@@ -112,7 +112,6 @@ struct RequestBehaviourGroup {
     }
 }
 
-
 //MARK: Type erased Requests and Responses
 
 public typealias AnyResponse = APIResponse<AnyResponseValue>


### PR DESCRIPTION
This replaces the custom fork of Stencil with StencilSwiftKit.
Resolves #48

Downsides are:
- A huge performance impact. This seems to be due to the upgrade to Stencil 0.12.0. This should be fixed by https://github.com/stencilproject/Stencil/pull/226
- Line breaks are not handled correctly. This is using the automatic line break removal feature of `StencilSwiftTemplate`. This should be fixed properly by https://github.com/stencilproject/Stencil/pull/92

EDIT:
- performance regression has been resolved
- line break issues are resolved except for the removal of line breaks in strings (like descriptions)