### PR TITLE
add ability to encode encodable objects

### DIFF
--- a/Templates/Swift/Sources/AnyCodable.swift
+++ b/Templates/Swift/Sources/AnyCodable.swift
@@ -76,6 +76,8 @@ extension AnyCodable: Codable {
             try container.encode(array.map { AnyCodable($0) })
         case let dictionary as [String: Any?]:
             try container.encode(dictionary.mapValues { AnyCodable($0) })
+        case let object as Encodable:
+            try object.encode(to: encoder)
         default:
             let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyCodable value cannot be encoded")
             throw EncodingError.invalidValue(self.value, context)


### PR DESCRIPTION
This PR will add ability to encode objects which are assigned to dictionary value.
For example, both Event and Item are generated by SwagGen:
```swift
struct Event: Codable {
    var detail: [String: Any]?
}

struct Item: Codable {
    var id: String
    var title: String
}

let item = Item(id: "123", title: "Game of Thrones")
let event = Event(detail: ["item": item])
```
Then calling `JSONEncoder().encode(event)` will throw `invalidValue` error.

To get above example work, the Event can only be constructed like this:
```swift
let item: [String: Any] = ["id": "123", "title": "Game of Thrones"]
let event = Event(detail: item)
```