### PR TITLE
Fix date formatting of DateDay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Fixed crash in Swift template when not using any RequestBehaviours #108
+- Fixed date formatting of `DateDay` properties #114
 
 [Commits](https://github.com/yonaskolb/SwagGen/compare/3.0.0...3.0.1)
 

--- a/Specs/Petstore/generated/Swift/README.md
+++ b/Specs/Petstore/generated/Swift/README.md
@@ -99,7 +99,7 @@ Dates are encoded and decoded differently according to the swagger date format. 
     - `DateTime.dateEncodingFormatter`: defaults to `yyyy-MM-dd'T'HH:mm:ss.Z`
     - `DateTime.dateDecodingFormatters`: an array of date formatters. The first one to decode successfully will be used
 - `date`
-    - `DateDay.dateFormatter`: defaults to `YYY-MM-dd`
+    - `DateDay.dateFormatter`: defaults to `yyyy-MM-dd`
 
 #### APIClientError
 This is error enum that `APIResponse.result` may contain:

--- a/Specs/Petstore/generated/Swift/Sources/Coding.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Coding.swift
@@ -221,7 +221,7 @@ public struct DateDay: Codable, Comparable {
     /// The date formatter used for encoding and decoding
     public static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYY-MM-dd"
+        formatter.dateFormat = "yyyy-MM-dd"
         formatter.calendar = .current
         return formatter
     }()

--- a/Specs/PetstoreTest/generated/Swift/README.md
+++ b/Specs/PetstoreTest/generated/Swift/README.md
@@ -99,7 +99,7 @@ Dates are encoded and decoded differently according to the swagger date format. 
     - `DateTime.dateEncodingFormatter`: defaults to `yyyy-MM-dd'T'HH:mm:ss.Z`
     - `DateTime.dateDecodingFormatters`: an array of date formatters. The first one to decode successfully will be used
 - `date`
-    - `DateDay.dateFormatter`: defaults to `YYY-MM-dd`
+    - `DateDay.dateFormatter`: defaults to `yyyy-MM-dd`
 
 #### APIClientError
 This is error enum that `APIResponse.result` may contain:

--- a/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
@@ -221,7 +221,7 @@ public struct DateDay: Codable, Comparable {
     /// The date formatter used for encoding and decoding
     public static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYY-MM-dd"
+        formatter.dateFormat = "yyyy-MM-dd"
         formatter.calendar = .current
         return formatter
     }()

--- a/Specs/Rocket/generated/Swift/README.md
+++ b/Specs/Rocket/generated/Swift/README.md
@@ -99,7 +99,7 @@ Dates are encoded and decoded differently according to the swagger date format. 
     - `DateTime.dateEncodingFormatter`: defaults to `yyyy-MM-dd'T'HH:mm:ss.Z`
     - `DateTime.dateDecodingFormatters`: an array of date formatters. The first one to decode successfully will be used
 - `date`
-    - `DateDay.dateFormatter`: defaults to `YYY-MM-dd`
+    - `DateDay.dateFormatter`: defaults to `yyyy-MM-dd`
 
 #### APIClientError
 This is error enum that `APIResponse.result` may contain:

--- a/Specs/Rocket/generated/Swift/Sources/Coding.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Coding.swift
@@ -221,7 +221,7 @@ public struct DateDay: Codable, Comparable {
     /// The date formatter used for encoding and decoding
     public static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYY-MM-dd"
+        formatter.dateFormat = "yyyy-MM-dd"
         formatter.calendar = .current
         return formatter
     }()

--- a/Specs/TBX/generated/Swift/README.md
+++ b/Specs/TBX/generated/Swift/README.md
@@ -99,7 +99,7 @@ Dates are encoded and decoded differently according to the swagger date format. 
     - `DateTime.dateEncodingFormatter`: defaults to `yyyy-MM-dd'T'HH:mm:ss.Z`
     - `DateTime.dateDecodingFormatters`: an array of date formatters. The first one to decode successfully will be used
 - `date`
-    - `DateDay.dateFormatter`: defaults to `YYY-MM-dd`
+    - `DateDay.dateFormatter`: defaults to `yyyy-MM-dd`
 
 #### APIClientError
 This is error enum that `APIResponse.result` may contain:

--- a/Specs/TBX/generated/Swift/Sources/Coding.swift
+++ b/Specs/TBX/generated/Swift/Sources/Coding.swift
@@ -221,7 +221,7 @@ public struct DateDay: Codable, Comparable {
     /// The date formatter used for encoding and decoding
     public static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYY-MM-dd"
+        formatter.dateFormat = "yyyy-MM-dd"
         formatter.calendar = .current
         return formatter
     }()

--- a/Specs/TFL/generated/Swift/README.md
+++ b/Specs/TFL/generated/Swift/README.md
@@ -99,7 +99,7 @@ Dates are encoded and decoded differently according to the swagger date format. 
     - `DateTime.dateEncodingFormatter`: defaults to `yyyy-MM-dd'T'HH:mm:ss.Z`
     - `DateTime.dateDecodingFormatters`: an array of date formatters. The first one to decode successfully will be used
 - `date`
-    - `DateDay.dateFormatter`: defaults to `YYY-MM-dd`
+    - `DateDay.dateFormatter`: defaults to `yyyy-MM-dd`
 
 #### APIClientError
 This is error enum that `APIResponse.result` may contain:

--- a/Specs/TFL/generated/Swift/Sources/Coding.swift
+++ b/Specs/TFL/generated/Swift/Sources/Coding.swift
@@ -221,7 +221,7 @@ public struct DateDay: Codable, Comparable {
     /// The date formatter used for encoding and decoding
     public static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYY-MM-dd"
+        formatter.dateFormat = "yyyy-MM-dd"
         formatter.calendar = .current
         return formatter
     }()

--- a/Specs/TestSpec/generated/Swift/README.md
+++ b/Specs/TestSpec/generated/Swift/README.md
@@ -99,7 +99,7 @@ Dates are encoded and decoded differently according to the swagger date format. 
     - `DateTime.dateEncodingFormatter`: defaults to `yyyy-MM-dd'T'HH:mm:ss.Z`
     - `DateTime.dateDecodingFormatters`: an array of date formatters. The first one to decode successfully will be used
 - `date`
-    - `DateDay.dateFormatter`: defaults to `YYY-MM-dd`
+    - `DateDay.dateFormatter`: defaults to `yyyy-MM-dd`
 
 #### APIClientError
 This is error enum that `APIResponse.result` may contain:

--- a/Specs/TestSpec/generated/Swift/Sources/Coding.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Coding.swift
@@ -221,7 +221,7 @@ public struct DateDay: Codable, Comparable {
     /// The date formatter used for encoding and decoding
     public static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYY-MM-dd"
+        formatter.dateFormat = "yyyy-MM-dd"
         formatter.calendar = .current
         return formatter
     }()

--- a/Templates/Swift/README.md
+++ b/Templates/Swift/README.md
@@ -99,7 +99,7 @@ Dates are encoded and decoded differently according to the swagger date format. 
     - `DateTime.dateEncodingFormatter`: defaults to `yyyy-MM-dd'T'HH:mm:ss.Z`
     - `DateTime.dateDecodingFormatters`: an array of date formatters. The first one to decode successfully will be used
 - `date`
-    - `DateDay.dateFormatter`: defaults to `YYY-MM-dd`
+    - `DateDay.dateFormatter`: defaults to `yyyy-MM-dd`
 
 #### APIClientError
 This is error enum that `APIResponse.result` may contain:

--- a/Templates/Swift/Sources/Coding.swift
+++ b/Templates/Swift/Sources/Coding.swift
@@ -218,7 +218,7 @@ public struct DateDay: Codable, Comparable {
     /// The date formatter used for encoding and decoding
     public static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "YYY-MM-dd"
+        formatter.dateFormat = "yyyy-MM-dd"
         formatter.calendar = .current
         return formatter
     }()


### PR DESCRIPTION
This fixes the coding of `DateDay` which is used for swagger properties with the `date` format.
Dates between the 25-31 of December of many years were not being encoded properly. More details here https://stackoverflow.com/questions/12423179/nsdateformatter-show-wrong-year