### PR TITLE
Remove unused `import Rainbow` in Generator.swift

### DIFF
--- a/Sources/SwagGen/GenerateCommand.swift
+++ b/Sources/SwagGen/GenerateCommand.swift
@@ -3,6 +3,7 @@ import PathKit
 import SwagGenKit
 import Swagger
 import SwiftCLI
+import Rainbow
 import Yams
 
 // TODO: remove custom newline spacing once https://github.com/jakeheis/SwiftCLI/pull/58 get's merged and integrated

--- a/Sources/SwagGenKit/Generator.swift
+++ b/Sources/SwagGenKit/Generator.swift
@@ -1,7 +1,6 @@
 import Foundation
 import JSONUtilities
 import PathKit
-import Rainbow
 import Stencil
 
 public class Generator {


### PR DESCRIPTION
source file in SwagGenKit target should not import Rainbow target which not described as a dependency of SwagGenKit in Package.swift.