### PR TITLE
Making Enum conform to `Equatable` and `CaseIterable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@
 
 ### Changed
 - Updated Swift template #117 #118 #120 #121
+- Making `Enum` conform to  Equatable and CaseIterable
 
 ### Removed
 - Removed support for Swagger 2 #118
+- Removed cases property in `Enum`
 
 [Commits](https://github.com/yonaskolb/SwagGen/compare/3.0.2...4.0.0)
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumArrays.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumArrays.swift
@@ -7,24 +7,34 @@ import Foundation
 
 public class EnumArrays: APIModel {
 
+    #if swift(>=4.2)
+    public enum ArrayEnum: String, Codable, Equatable, CaseIterable {
+    #else
     public enum ArrayEnum: String, Codable {
+    #endif
         case fish = "fish"
         case crab = "crab"
-
+        #if swift(<4.2)
         public static let cases: [ArrayEnum] = [
           .fish,
           .crab,
         ]
+        #endif
     }
 
+    #if swift(>=4.2)
+    public enum JustSymbol: String, Codable, Equatable, CaseIterable {
+    #else
     public enum JustSymbol: String, Codable {
+    #endif
         case greaterThanOrEqualTo = ">="
         case dollar = "$"
-
+        #if swift(<4.2)
         public static let cases: [JustSymbol] = [
           .greaterThanOrEqualTo,
           .dollar,
         ]
+        #endif
     }
 
     public var arrayEnum: [ArrayEnum]?

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumClass.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumClass.swift
@@ -5,14 +5,19 @@
 
 import Foundation
 
+#if swift(>=4.2)
+public enum EnumClass: String, Codable, Equatable, CaseIterable {
+#else
 public enum EnumClass: String, Codable {
+#endif
     case abc = "_abc"
     case efg = "-efg"
     case xyz = "(xyz)"
-
+    #if swift(<4.2)
     public static let cases: [EnumClass] = [
       .abc,
       .efg,
       .xyz,
     ]
+    #endif
 }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumTest.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/EnumTest.swift
@@ -7,36 +7,51 @@ import Foundation
 
 public class EnumTest: APIModel {
 
+    #if swift(>=4.2)
+    public enum EnumInteger: Int, Codable, Equatable, CaseIterable {
+    #else
     public enum EnumInteger: Int, Codable {
+    #endif
         case _1 = 1
         case negative1 = -1
-
+        #if swift(<4.2)
         public static let cases: [EnumInteger] = [
           ._1,
           .negative1,
         ]
+        #endif
     }
 
+    #if swift(>=4.2)
+    public enum EnumNumber: Double, Codable, Equatable, CaseIterable {
+    #else
     public enum EnumNumber: Double, Codable {
+    #endif
         case _11 = 1.1
         case negative12 = -1.2
-
+        #if swift(<4.2)
         public static let cases: [EnumNumber] = [
           ._11,
           .negative12,
         ]
+        #endif
     }
 
+    #if swift(>=4.2)
+    public enum EnumString: String, Codable, Equatable, CaseIterable {
+    #else
     public enum EnumString: String, Codable {
+    #endif
         case upper = "UPPER"
         case lower = "lower"
         case empty = ""
-
+        #if swift(<4.2)
         public static let cases: [EnumString] = [
           .upper,
           .lower,
           .empty,
         ]
+        #endif
     }
 
     public var enumInteger: EnumInteger?

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/MapTest.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/MapTest.swift
@@ -7,14 +7,19 @@ import Foundation
 
 public class MapTest: APIModel {
 
+    #if swift(>=4.2)
+    public enum MapOfEnumString: String, Codable, Equatable, CaseIterable {
+    #else
     public enum MapOfEnumString: String, Codable {
+    #endif
         case upper = "UPPER"
         case lower = "lower"
-
+        #if swift(<4.2)
         public static let cases: [MapOfEnumString] = [
           .upper,
           .lower,
         ]
+        #endif
     }
 
     public var mapMapOfString: [String: [String: String]]?

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Order.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Order.swift
@@ -8,16 +8,21 @@ import Foundation
 public class Order: APIModel {
 
     /** Order Status */
+    #if swift(>=4.2)
+    public enum Status: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Status: String, Codable {
+    #endif
         case placed = "placed"
         case approved = "approved"
         case delivered = "delivered"
-
+        #if swift(<4.2)
         public static let cases: [Status] = [
           .placed,
           .approved,
           .delivered,
         ]
+        #endif
     }
 
     public var complete: Bool?

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/OuterEnum.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/OuterEnum.swift
@@ -5,14 +5,19 @@
 
 import Foundation
 
+#if swift(>=4.2)
+public enum OuterEnum: String, Codable, Equatable, CaseIterable {
+#else
 public enum OuterEnum: String, Codable {
+#endif
     case placed = "placed"
     case approved = "approved"
     case delivered = "delivered"
-
+    #if swift(<4.2)
     public static let cases: [OuterEnum] = [
       .placed,
       .approved,
       .delivered,
     ]
+    #endif
 }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Models/Pet.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Models/Pet.swift
@@ -8,16 +8,21 @@ import Foundation
 public class Pet: APIModel {
 
     /** pet status in the store */
+    #if swift(>=4.2)
+    public enum Status: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Status: String, Codable {
+    #endif
         case available = "available"
         case pending = "pending"
         case sold = "sold"
-
+        #if swift(<4.2)
         public static let cases: [Status] = [
           .available,
           .pending,
           .sold,
         ]
+        #endif
     }
 
     public var name: String

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEnumParameters.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEnumParameters.swift
@@ -13,97 +13,137 @@ extension PetstoreTest.Fake {
         public static let service = APIService<Response>(id: "testEnumParameters", tag: "fake", method: "GET", path: "/fake", hasBody: true)
 
         /** Header parameter enum test (string array) */
+        #if swift(>=4.2)
+        public enum EnumHeaderStringArray: String, Codable, Equatable, CaseIterable {
+        #else
         public enum EnumHeaderStringArray: String, Codable {
+        #endif
             case greaterThan = ">"
             case dollar = "$"
-
+            #if swift(<4.2)
             public static let cases: [EnumHeaderStringArray] = [
               .greaterThan,
               .dollar,
             ]
+            #endif
         }
 
         /** Header parameter enum test (string) */
+        #if swift(>=4.2)
+        public enum EnumHeaderString: String, Codable, Equatable, CaseIterable {
+        #else
         public enum EnumHeaderString: String, Codable {
+        #endif
             case abc = "_abc"
             case efg = "-efg"
             case xyz = "(xyz)"
-
+            #if swift(<4.2)
             public static let cases: [EnumHeaderString] = [
               .abc,
               .efg,
               .xyz,
             ]
+            #endif
         }
 
         /** Query parameter enum test (string array) */
+        #if swift(>=4.2)
+        public enum EnumQueryStringArray: String, Codable, Equatable, CaseIterable {
+        #else
         public enum EnumQueryStringArray: String, Codable {
+        #endif
             case greaterThan = ">"
             case dollar = "$"
-
+            #if swift(<4.2)
             public static let cases: [EnumQueryStringArray] = [
               .greaterThan,
               .dollar,
             ]
+            #endif
         }
 
         /** Query parameter enum test (string) */
+        #if swift(>=4.2)
+        public enum EnumQueryString: String, Codable, Equatable, CaseIterable {
+        #else
         public enum EnumQueryString: String, Codable {
+        #endif
             case abc = "_abc"
             case efg = "-efg"
             case xyz = "(xyz)"
-
+            #if swift(<4.2)
             public static let cases: [EnumQueryString] = [
               .abc,
               .efg,
               .xyz,
             ]
+            #endif
         }
 
         /** Query parameter enum test (double) */
+        #if swift(>=4.2)
+        public enum EnumQueryInteger: Int, Codable, Equatable, CaseIterable {
+        #else
         public enum EnumQueryInteger: Int, Codable {
+        #endif
             case _1 = 1
             case negative2 = -2
-
+            #if swift(<4.2)
             public static let cases: [EnumQueryInteger] = [
               ._1,
               .negative2,
             ]
+            #endif
         }
 
         /** Form parameter enum test (string) */
+        #if swift(>=4.2)
+        public enum EnumFormString: String, Codable, Equatable, CaseIterable {
+        #else
         public enum EnumFormString: String, Codable {
+        #endif
             case abc = "_abc"
             case efg = "-efg"
             case xyz = "(xyz)"
-
+            #if swift(<4.2)
             public static let cases: [EnumFormString] = [
               .abc,
               .efg,
               .xyz,
             ]
+            #endif
         }
 
         /** Form parameter enum test (string array) */
+        #if swift(>=4.2)
+        public enum EnumFormStringArray: String, Codable, Equatable, CaseIterable {
+        #else
         public enum EnumFormStringArray: String, Codable {
+        #endif
             case greaterThan = ">"
             case dollar = "$"
-
+            #if swift(<4.2)
             public static let cases: [EnumFormStringArray] = [
               .greaterThan,
               .dollar,
             ]
+            #endif
         }
 
         /** Query parameter enum test (double) */
+        #if swift(>=4.2)
+        public enum EnumQueryDouble: Double, Codable, Equatable, CaseIterable {
+        #else
         public enum EnumQueryDouble: Double, Codable {
+        #endif
             case _11 = 1.1
             case negative12 = -1.2
-
+            #if swift(<4.2)
             public static let cases: [EnumQueryDouble] = [
               ._11,
               .negative12,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/FindPetsByStatus.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/FindPetsByStatus.swift
@@ -17,16 +17,21 @@ extension PetstoreTest.Pet {
         public static let service = APIService<Response>(id: "findPetsByStatus", tag: "pet", method: "GET", path: "/pet/findByStatus", hasBody: false, securityRequirement: SecurityRequirement(type: "petstore_auth", scopes: ["write:pets", "read:pets"]))
 
         /** Status values that need to be considered for filter */
+        #if swift(>=4.2)
+        public enum Status: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Status: String, Codable {
+        #endif
             case available = "available"
             case pending = "pending"
             case sold = "sold"
-
+            #if swift(<4.2)
             public static let cases: [Status] = [
               .available,
               .pending,
               .sold,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/Rocket/generated/Swift/Sources/Enums/FeatureFlags.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Enums/FeatureFlags.swift
@@ -14,14 +14,19 @@ clients as these formats evolve under the current major version.
 - `ldp` - Dynamic list detail pages with schedulable rows.
 See the `feature-flags.md` for available flag details.
  */
+#if swift(>=4.2)
+public enum FeatureFlags: String, Codable, Equatable, CaseIterable {
+#else
 public enum FeatureFlags: String, Codable {
+#endif
     case all = "all"
     case idp = "idp"
     case ldp = "ldp"
-
+    #if swift(<4.2)
     public static let cases: [FeatureFlags] = [
       .all,
       .idp,
       .ldp,
     ]
+    #endif
 }

--- a/Specs/Rocket/generated/Swift/Sources/Enums/ItemType.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Enums/ItemType.swift
@@ -4,7 +4,11 @@
 //
 
 /** The item type to filter by. Defaults to unspecified. */
+#if swift(>=4.2)
+public enum ItemType: String, Codable, Equatable, CaseIterable {
+#else
 public enum ItemType: String, Codable {
+#endif
     case movie = "movie"
     case show = "show"
     case season = "season"
@@ -13,7 +17,7 @@ public enum ItemType: String, Codable {
     case link = "link"
     case trailer = "trailer"
     case channel = "channel"
-
+    #if swift(<4.2)
     public static let cases: [ItemType] = [
       .movie,
       .show,
@@ -24,4 +28,5 @@ public enum ItemType: String, Codable {
       .trailer,
       .channel,
     ]
+    #endif
 }

--- a/Specs/Rocket/generated/Swift/Sources/Enums/ListOrder.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Enums/ListOrder.swift
@@ -4,12 +4,17 @@
 //
 
 /** The list sort order, either 'asc' or 'desc'. */
+#if swift(>=4.2)
+public enum ListOrder: String, Codable, Equatable, CaseIterable {
+#else
 public enum ListOrder: String, Codable {
+#endif
     case asc = "asc"
     case desc = "desc"
-
+    #if swift(<4.2)
     public static let cases: [ListOrder] = [
       .asc,
       .desc,
     ]
+    #endif
 }

--- a/Specs/Rocket/generated/Swift/Sources/Enums/ListOrderBy.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Enums/ListOrderBy.swift
@@ -4,14 +4,19 @@
 //
 
 /** What to order by. */
+#if swift(>=4.2)
+public enum ListOrderBy: String, Codable, Equatable, CaseIterable {
+#else
 public enum ListOrderBy: String, Codable {
+#endif
     case az = "a-z"
     case releaseYear = "release-year"
     case dateAdded = "date-added"
-
+    #if swift(<4.2)
     public static let cases: [ListOrderBy] = [
       .az,
       .releaseYear,
       .dateAdded,
     ]
+    #endif
 }

--- a/Specs/Rocket/generated/Swift/Sources/Enums/MediaFileDelivery.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Enums/MediaFileDelivery.swift
@@ -4,14 +4,19 @@
 //
 
 /** The video delivery type you require. */
+#if swift(>=4.2)
+public enum MediaFileDelivery: String, Codable, Equatable, CaseIterable {
+#else
 public enum MediaFileDelivery: String, Codable {
+#endif
     case stream = "stream"
     case progressive = "progressive"
     case download = "download"
-
+    #if swift(<4.2)
     public static let cases: [MediaFileDelivery] = [
       .stream,
       .progressive,
       .download,
     ]
+    #endif
 }

--- a/Specs/Rocket/generated/Swift/Sources/Enums/MediaFileResolution.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Enums/MediaFileResolution.swift
@@ -4,14 +4,19 @@
 //
 
 /** The maximum resolution the device to playback the media can present. */
+#if swift(>=4.2)
+public enum MediaFileResolution: String, Codable, Equatable, CaseIterable {
+#else
 public enum MediaFileResolution: String, Codable {
+#endif
     case hd1080 = "HD-1080"
     case hd720 = "HD-720"
     case sd = "SD"
-
+    #if swift(<4.2)
     public static let cases: [MediaFileResolution] = [
       .hd1080,
       .hd720,
       .sd,
     ]
+    #endif
 }

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccessToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccessToken.swift
@@ -8,14 +8,19 @@ import Foundation
 public class AccessToken: APIModel {
 
     /** The type of the token. */
+    #if swift(>=4.2)
+    public enum `Type`: String, Codable, Equatable, CaseIterable {
+    #else
     public enum `Type`: String, Codable {
+    #endif
         case userAccount = "UserAccount"
         case userProfile = "UserProfile"
-
+        #if swift(<4.2)
         public static let cases: [`Type`] = [
           .userAccount,
           .userProfile,
         ]
+        #endif
     }
 
     /** The token value used for authenticated requests. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/AccountTokenRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/AccountTokenRequest.swift
@@ -10,18 +10,23 @@ public class AccountTokenRequest: APIModel {
     /** The scope(s) of the tokens required.
     For each scope listed an Account and Profile token of that scope will be returned
      */
+    #if swift(>=4.2)
+    public enum Scopes: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Scopes: String, Codable {
+    #endif
         case catalog = "Catalog"
         case commerce = "Commerce"
         case settings = "Settings"
         case playback = "Playback"
-
+        #if swift(<4.2)
         public static let cases: [Scopes] = [
           .catalog,
           .commerce,
           .settings,
           .playback,
         ]
+        #endif
     }
 
     /** If you specify a cookie type then a content filter cookie will be returned
@@ -32,14 +37,19 @@ public class AccountTokenRequest: APIModel {
     If type `Persistent` the cookie will have a medium term lifespan.
     If undefined no cookies will be set.
      */
+    #if swift(>=4.2)
+    public enum CookieType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum CookieType: String, Codable {
+    #endif
         case session = "Session"
         case persistent = "Persistent"
-
+        #if swift(<4.2)
         public static let cases: [CookieType] = [
           .session,
           .persistent,
         ]
+        #endif
     }
 
     /** The email associated with the account. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/Credit.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Credit.swift
@@ -8,7 +8,11 @@ import Foundation
 public class Credit: Person {
 
     /** The type of role the credit performed, e.g. actor. */
+    #if swift(>=4.2)
+    public enum Role: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Role: String, Codable {
+    #endif
         case actor = "actor"
         case associateproducer = "associateproducer"
         case coactor = "coactor"
@@ -24,7 +28,7 @@ public class Credit: Person {
         case thememusicby = "thememusicby"
         case voice = "voice"
         case writer = "writer"
-
+        #if swift(<4.2)
         public static let cases: [Role] = [
           .actor,
           .associateproducer,
@@ -42,6 +46,7 @@ public class Credit: Person {
           .voice,
           .writer,
         ]
+        #endif
     }
 
     /** The type of role the credit performed, e.g. actor. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/ExclusionRule.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ExclusionRule.swift
@@ -9,13 +9,17 @@ import Foundation
 public class ExclusionRule: APIModel {
 
     /** Defines playback exclusion rules for an Offer or Entitlement. */
+    #if swift(>=4.2)
+    public enum ExcludeDelivery: String, Codable, Equatable, CaseIterable {
+    #else
     public enum ExcludeDelivery: String, Codable {
+    #endif
         case stream = "Stream"
         case download = "Download"
         case streamOrDownload = "StreamOrDownload"
         case progressiveDownload = "ProgressiveDownload"
         case none = "None"
-
+        #if swift(<4.2)
         public static let cases: [ExcludeDelivery] = [
           .stream,
           .download,
@@ -23,21 +27,27 @@ public class ExclusionRule: APIModel {
           .progressiveDownload,
           .none,
         ]
+        #endif
     }
 
     /** Defines playback exclusion rules for an Offer or Entitlement. */
+    #if swift(>=4.2)
+    public enum ExcludeMinResolution: String, Codable, Equatable, CaseIterable {
+    #else
     public enum ExcludeMinResolution: String, Codable {
+    #endif
         case sd = "SD"
         case hd720 = "HD-720"
         case hd1080 = "HD-1080"
         case unknown = "Unknown"
-
+        #if swift(<4.2)
         public static let cases: [ExcludeMinResolution] = [
           .sd,
           .hd720,
           .hd1080,
           .unknown,
         ]
+        #endif
     }
 
     public var description: String?

--- a/Specs/Rocket/generated/Swift/Sources/Models/MediaFile.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/MediaFile.swift
@@ -8,31 +8,41 @@ import Foundation
 public class MediaFile: APIModel {
 
     /** The way in which the media file is delivered. */
+    #if swift(>=4.2)
+    public enum DeliveryType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum DeliveryType: String, Codable {
+    #endif
         case stream = "Stream"
         case progressive = "Progressive"
         case download = "Download"
-
+        #if swift(<4.2)
         public static let cases: [DeliveryType] = [
           .stream,
           .progressive,
           .download,
         ]
+        #endif
     }
 
     /** The resolution of the video media. */
+    #if swift(>=4.2)
+    public enum Resolution: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Resolution: String, Codable {
+    #endif
         case sd = "SD"
         case hd720 = "HD-720"
         case hd1080 = "HD-1080"
         case unknown = "Unknown"
-
+        #if swift(<4.2)
         public static let cases: [Resolution] = [
           .sd,
           .hd720,
           .hd1080,
           .unknown,
         ]
+        #endif
     }
 
     /** The name of the media file. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/Offer.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Offer.swift
@@ -7,14 +7,19 @@ import Foundation
 
 public class Offer: OfferRights {
 
+    #if swift(>=4.2)
+    public enum Availability: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Availability: String, Codable {
+    #endif
         case available = "Available"
         case comingSoon = "ComingSoon"
-
+        #if swift(<4.2)
         public static let cases: [Availability] = [
           .available,
           .comingSoon,
         ]
+        #endif
     }
 
     public var price: Float

--- a/Specs/Rocket/generated/Swift/Sources/Models/OfferRights.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/OfferRights.swift
@@ -9,13 +9,17 @@ import Foundation
 public class OfferRights: APIModel {
 
     /** The base type for both Offer and Entitlement. */
+    #if swift(>=4.2)
+    public enum DeliveryType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum DeliveryType: String, Codable {
+    #endif
         case stream = "Stream"
         case download = "Download"
         case streamOrDownload = "StreamOrDownload"
         case progressiveDownload = "ProgressiveDownload"
         case none = "None"
-
+        #if swift(<4.2)
         public static let cases: [DeliveryType] = [
           .stream,
           .download,
@@ -23,31 +27,41 @@ public class OfferRights: APIModel {
           .progressiveDownload,
           .none,
         ]
+        #endif
     }
 
     /** The base type for both Offer and Entitlement. */
+    #if swift(>=4.2)
+    public enum Resolution: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Resolution: String, Codable {
+    #endif
         case sd = "SD"
         case hd720 = "HD-720"
         case hd1080 = "HD-1080"
         case unknown = "Unknown"
-
+        #if swift(<4.2)
         public static let cases: [Resolution] = [
           .sd,
           .hd720,
           .hd1080,
           .unknown,
         ]
+        #endif
     }
 
     /** The base type for both Offer and Entitlement. */
+    #if swift(>=4.2)
+    public enum Ownership: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Ownership: String, Codable {
+    #endif
         case subscription = "Subscription"
         case free = "Free"
         case rent = "Rent"
         case own = "Own"
         case none = "None"
-
+        #if swift(<4.2)
         public static let cases: [Ownership] = [
           .subscription,
           .free,
@@ -55,6 +69,7 @@ public class OfferRights: APIModel {
           .own,
           .none,
         ]
+        #endif
     }
 
     public var deliveryType: DeliveryType

--- a/Specs/Rocket/generated/Swift/Sources/Models/PageEntry.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PageEntry.swift
@@ -12,7 +12,11 @@ Also defines what visual template should be used to render that content.
 public class PageEntry: APIModel {
 
     /** The type of PageEntry. Used to help identify what type of content will be presented. */
+    #if swift(>=4.2)
+    public enum `Type`: String, Codable, Equatable, CaseIterable {
+    #else
     public enum `Type`: String, Codable {
+    #endif
         case itemEntry = "ItemEntry"
         case itemDetailEntry = "ItemDetailEntry"
         case listEntry = "ListEntry"
@@ -22,7 +26,7 @@ public class PageEntry: APIModel {
         case imageEntry = "ImageEntry"
         case customEntry = "CustomEntry"
         case peopleEntry = "PeopleEntry"
-
+        #if swift(<4.2)
         public static let cases: [`Type`] = [
           .itemEntry,
           .itemDetailEntry,
@@ -34,6 +38,7 @@ public class PageEntry: APIModel {
           .customEntry,
           .peopleEntry,
         ]
+        #endif
     }
 
     /** The unique identifier for a page entry. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/PaginationAuth.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/PaginationAuth.swift
@@ -8,27 +8,37 @@ import Foundation
 public class PaginationAuth: APIModel {
 
     /** The token type required to load the list. */
+    #if swift(>=4.2)
+    public enum `Type`: String, Codable, Equatable, CaseIterable {
+    #else
     public enum `Type`: String, Codable {
+    #endif
         case userAccount = "UserAccount"
         case userProfile = "UserProfile"
-
+        #if swift(<4.2)
         public static let cases: [`Type`] = [
           .userAccount,
           .userProfile,
         ]
+        #endif
     }
 
     /** The token scope required. */
+    #if swift(>=4.2)
+    public enum Scope: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Scope: String, Codable {
+    #endif
         case catalog = "Catalog"
         case commerce = "Commerce"
         case settings = "Settings"
-
+        #if swift(<4.2)
         public static let cases: [Scope] = [
           .catalog,
           .commerce,
           .settings,
         ]
+        #endif
     }
 
     /** The token type required to load the list. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/Plan.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Plan.swift
@@ -8,40 +8,55 @@ import Foundation
 public class Plan: APIModel {
 
     /** The type of plan. */
+    #if swift(>=4.2)
+    public enum `Type`: String, Codable, Equatable, CaseIterable {
+    #else
     public enum `Type`: String, Codable {
+    #endif
         case free = "Free"
         case subscription = "Subscription"
-
+        #if swift(<4.2)
         public static let cases: [`Type`] = [
           .free,
           .subscription,
         ]
+        #endif
     }
 
     /** The revenue type a plan targets. */
+    #if swift(>=4.2)
+    public enum RevenueType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum RevenueType: String, Codable {
+    #endif
         case tvod = "TVOD"
         case svod = "SVOD"
-
+        #if swift(<4.2)
         public static let cases: [RevenueType] = [
           .tvod,
           .svod,
         ]
+        #endif
     }
 
     /** The type of billing period used. */
+    #if swift(>=4.2)
+    public enum BillingPeriodType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum BillingPeriodType: String, Codable {
+    #endif
         case week = "week"
         case month = "month"
         case year = "year"
         case none = "none"
-
+        #if swift(<4.2)
         public static let cases: [BillingPeriodType] = [
           .week,
           .month,
           .year,
           .none,
         ]
+        #endif
     }
 
     /** The identifier of a plan. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/ProfileTokenRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/ProfileTokenRequest.swift
@@ -8,16 +8,21 @@ import Foundation
 public class ProfileTokenRequest: APIModel {
 
     /** The scope(s) of the token(s) required. */
+    #if swift(>=4.2)
+    public enum Scopes: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Scopes: String, Codable {
+    #endif
         case catalog = "Catalog"
         case commerce = "Commerce"
         case settings = "Settings"
-
+        #if swift(<4.2)
         public static let cases: [Scopes] = [
           .catalog,
           .commerce,
           .settings,
         ]
+        #endif
     }
 
     /** The id of the profile the token should grant access rights to. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/Subscription.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/Subscription.swift
@@ -8,13 +8,17 @@ import Foundation
 public class Subscription: APIModel {
 
     /** The status of a subscription. */
+    #if swift(>=4.2)
+    public enum Status: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Status: String, Codable {
+    #endif
         case active = "Active"
         case cancelled = "Cancelled"
         case lapsed = "Lapsed"
         case expired = "Expired"
         case none = "None"
-
+        #if swift(<4.2)
         public static let cases: [Status] = [
           .active,
           .cancelled,
@@ -22,6 +26,7 @@ public class Subscription: APIModel {
           .expired,
           .none,
         ]
+        #endif
     }
 
     /** The unique subscription code. */

--- a/Specs/Rocket/generated/Swift/Sources/Models/TokenRefreshRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Models/TokenRefreshRequest.swift
@@ -15,14 +15,19 @@ public class TokenRefreshRequest: APIModel {
     If type `Persistent` the cookie will have a medium term lifespan.
     If undefined no cookies will be set.
      */
+    #if swift(>=4.2)
+    public enum CookieType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum CookieType: String, Codable {
+    #endif
         case session = "Session"
         case persistent = "Persistent"
-
+        #if swift(<4.2)
         public static let cases: [CookieType] = [
           .session,
           .persistent,
         ]
+        #endif
     }
 
     /** The token to refresh. */

--- a/Specs/Rocket/generated/Swift/Sources/Requests/App/GetAppConfig.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/App/GetAppConfig.swift
@@ -20,14 +20,18 @@ parameter, or if unspecified, getting all configuration.
         /** A comma delimited list of config objects to return.
         If none specified then all configuration is returned.
          */
+        #if swift(>=4.2)
+        public enum Include: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Include: String, Codable {
+        #endif
             case classification = "classification"
             case playback = "playback"
             case sitemap = "sitemap"
             case navigation = "navigation"
             case subscription = "subscription"
             case general = "general"
-
+            #if swift(<4.2)
             public static let cases: [Include] = [
               .classification,
               .playback,
@@ -36,6 +40,7 @@ parameter, or if unspecified, getting all configuration.
               .subscription,
               .general,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/App/GetPage.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/App/GetPage.swift
@@ -28,14 +28,19 @@ then what you pass to this endpoint would look like `/page?path=/search%3Fq%3Dth
         children of the show should only need to request expand of children.
         If an expand is specified which is not relevant to the item type, it will be ignored.
          */
+        #if swift(>=4.2)
+        public enum ItemDetailExpand: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ItemDetailExpand: String, Codable {
+        #endif
             case all = "all"
             case children = "children"
-
+            #if swift(<4.2)
             public static let cases: [ItemDetailExpand] = [
               .all,
               .children,
             ]
+            #endif
         }
 
         /** Only relevant when loading show detail pages as these embed a detailed item in the main page entry.
@@ -46,27 +51,37 @@ then what you pass to this endpoint would look like `/page?path=/search%3Fq%3Dth
         detail of the latest season with its list of child episode summaries, and also expand
         the detail of the show with its list of seasons summaries.
          */
+        #if swift(>=4.2)
+        public enum ItemDetailSelectSeason: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ItemDetailSelectSeason: String, Codable {
+        #endif
             case first = "first"
             case latest = "latest"
-
+            #if swift(<4.2)
             public static let cases: [ItemDetailSelectSeason] = [
               .first,
               .latest,
             ]
+            #endif
         }
 
         /** Only relevant to page entries of type `TextEntry`.
         Converts the value of a text page entry to the specified format.
          */
+        #if swift(>=4.2)
+        public enum TextEntryFormat: String, Codable, Equatable, CaseIterable {
+        #else
         public enum TextEntryFormat: String, Codable {
+        #endif
             case markdown = "markdown"
             case html = "html"
-
+            #if swift(<4.2)
             public static let cases: [TextEntryFormat] = [
               .markdown,
               .html,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItem.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/GetItem.swift
@@ -23,14 +23,19 @@ extension Rocket.Content {
         children of the show should only need to request expand of children.
         If an expand is specified which is not relevant to the item type, it will be ignored.
          */
+        #if swift(>=4.2)
+        public enum Expand: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Expand: String, Codable {
+        #endif
             case all = "all"
             case children = "children"
-
+            #if swift(<4.2)
             public static let cases: [Expand] = [
               .all,
               .children,
             ]
+            #endif
         }
 
         /** Given a provided show id, it can be useful to get the details of a child season. This option
@@ -40,14 +45,19 @@ extension Rocket.Content {
         its list of child episode summaries, and also expand the detail of the show with its list of seasons summaries.
         Note the `id` parameter must be a show id for this parameter to work correctly.
          */
+        #if swift(>=4.2)
+        public enum SelectSeason: String, Codable, Equatable, CaseIterable {
+        #else
         public enum SelectSeason: String, Codable {
+        #endif
             case first = "first"
             case latest = "latest"
-
+            #if swift(<4.2)
             public static let cases: [SelectSeason] = [
               .first,
               .latest,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Content/Search.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Content/Search.swift
@@ -17,16 +17,21 @@ extension Rocket.Content {
         If you don't want all of these types you can specifiy the specific
         includes you care about.
          */
+        #if swift(>=4.2)
+        public enum Include: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Include: String, Codable {
+        #endif
             case tv = "tv"
             case movies = "movies"
             case people = "people"
-
+            #if swift(<4.2)
             public static let cases: [Include] = [
               .tv,
               .movies,
               .people,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetRatingsList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetRatingsList.swift
@@ -15,14 +15,19 @@ extension Rocket.Profile {
         /** What to order by.
         Ordering by `date-modified` equates to ordering by the last rated date.
          */
+        #if swift(>=4.2)
+        public enum OrderBy: String, Codable, Equatable, CaseIterable {
+        #else
         public enum OrderBy: String, Codable {
+        #endif
             case dateAdded = "date-added"
             case dateModified = "date-modified"
-
+            #if swift(<4.2)
             public static let cases: [OrderBy] = [
               .dateAdded,
               .dateModified,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetWatchedList.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Profile/GetWatchedList.swift
@@ -15,14 +15,19 @@ extension Rocket.Profile {
         /** What to order by.
         Ordering by `date-modified` equates to ordering by the last watched date.
          */
+        #if swift(>=4.2)
+        public enum OrderBy: String, Codable, Equatable, CaseIterable {
+        #else
         public enum OrderBy: String, Codable {
+        #endif
             case dateAdded = "date-added"
             case dateModified = "date-modified"
-
+            #if swift(<4.2)
             public static let cases: [OrderBy] = [
               .dateAdded,
               .dateModified,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Models/Disruption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Disruption.swift
@@ -9,7 +9,11 @@ import Foundation
 public class Disruption: APIModel {
 
     /** Gets or sets the category of this dispruption. */
+    #if swift(>=4.2)
+    public enum Category: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Category: String, Codable {
+    #endif
         case undefined = "Undefined"
         case realTime = "RealTime"
         case plannedWork = "PlannedWork"
@@ -17,7 +21,7 @@ public class Disruption: APIModel {
         case event = "Event"
         case crowding = "Crowding"
         case statusAlert = "StatusAlert"
-
+        #if swift(<4.2)
         public static let cases: [Category] = [
           .undefined,
           .realTime,
@@ -27,6 +31,7 @@ public class Disruption: APIModel {
           .crowding,
           .statusAlert,
         ]
+        #endif
     }
 
     /** Gets or sets the additionaInfo of this disruption. */

--- a/Specs/TFL/generated/Swift/Sources/Models/EmissionsSurchargeVehicle.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/EmissionsSurchargeVehicle.swift
@@ -7,16 +7,21 @@ import Foundation
 
 public class EmissionsSurchargeVehicle: APIModel {
 
+    #if swift(>=4.2)
+    public enum Compliance: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Compliance: String, Codable {
+    #endif
         case notCompliant = "NotCompliant"
         case compliant = "Compliant"
         case exempt = "Exempt"
-
+        #if swift(<4.2)
         public static let cases: [Compliance] = [
           .notCompliant,
           .compliant,
           .exempt,
         ]
+        #endif
     }
 
     public var colour: String?

--- a/Specs/TFL/generated/Swift/Sources/Models/InstructionStep.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/InstructionStep.swift
@@ -7,7 +7,11 @@ import Foundation
 
 public class InstructionStep: APIModel {
 
+    #if swift(>=4.2)
+    public enum SkyDirectionDescription: String, Codable, Equatable, CaseIterable {
+    #else
     public enum SkyDirectionDescription: String, Codable {
+    #endif
         case north = "North"
         case northEast = "NorthEast"
         case east = "East"
@@ -16,7 +20,7 @@ public class InstructionStep: APIModel {
         case southWest = "SouthWest"
         case west = "West"
         case northWest = "NorthWest"
-
+        #if swift(<4.2)
         public static let cases: [SkyDirectionDescription] = [
           .north,
           .northEast,
@@ -27,9 +31,14 @@ public class InstructionStep: APIModel {
           .west,
           .northWest,
         ]
+        #endif
     }
 
+    #if swift(>=4.2)
+    public enum TrackType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum TrackType: String, Codable {
+    #endif
         case cycleSuperHighway = "CycleSuperHighway"
         case canalTowpath = "CanalTowpath"
         case quietRoad = "QuietRoad"
@@ -37,7 +46,7 @@ public class InstructionStep: APIModel {
         case busyRoads = "BusyRoads"
         case none = "None"
         case pushBike = "PushBike"
-
+        #if swift(<4.2)
         public static let cases: [TrackType] = [
           .cycleSuperHighway,
           .canalTowpath,
@@ -47,6 +56,7 @@ public class InstructionStep: APIModel {
           .none,
           .pushBike,
         ]
+        #endif
     }
 
     public var cumulativeDistance: Int?

--- a/Specs/TFL/generated/Swift/Sources/Models/Period.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/Period.swift
@@ -7,18 +7,23 @@ import Foundation
 
 public class Period: APIModel {
 
+    #if swift(>=4.2)
+    public enum `Type`: String, Codable, Equatable, CaseIterable {
+    #else
     public enum `Type`: String, Codable {
+    #endif
         case normal = "Normal"
         case frequencyHours = "FrequencyHours"
         case frequencyMinutes = "FrequencyMinutes"
         case unknown = "Unknown"
-
+        #if swift(<4.2)
         public static let cases: [`Type`] = [
           .normal,
           .frequencyHours,
           .frequencyMinutes,
           .unknown,
         ]
+        #endif
     }
 
     public var frequency: ServiceFrequency?

--- a/Specs/TFL/generated/Swift/Sources/Models/RoadProject.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/RoadProject.swift
@@ -7,14 +7,18 @@ import Foundation
 
 public class RoadProject: APIModel {
 
+    #if swift(>=4.2)
+    public enum Phase: String, Codable, Equatable, CaseIterable {
+    #else
     public enum Phase: String, Codable {
+    #endif
         case unscoped = "Unscoped"
         case concept = "Concept"
         case consultationEnded = "ConsultationEnded"
         case consultation = "Consultation"
         case construction = "Construction"
         case complete = "Complete"
-
+        #if swift(<4.2)
         public static let cases: [Phase] = [
           .unscoped,
           .concept,
@@ -23,6 +27,7 @@ public class RoadProject: APIModel {
           .construction,
           .complete,
         ]
+        #endif
     }
 
     public var boroughsBenefited: [String]?

--- a/Specs/TFL/generated/Swift/Sources/Models/SearchCriteria.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/SearchCriteria.swift
@@ -7,14 +7,19 @@ import Foundation
 
 public class SearchCriteria: APIModel {
 
+    #if swift(>=4.2)
+    public enum DateTimeType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum DateTimeType: String, Codable {
+    #endif
         case arriving = "Arriving"
         case departing = "Departing"
-
+        #if swift(<4.2)
         public static let cases: [DateTimeType] = [
           .arriving,
           .departing,
         ]
+        #endif
     }
 
     public var dateTime: DateTime?

--- a/Specs/TFL/generated/Swift/Sources/Models/StopPointSequence.swift
+++ b/Specs/TFL/generated/Swift/Sources/Models/StopPointSequence.swift
@@ -7,14 +7,19 @@ import Foundation
 
 public class StopPointSequence: APIModel {
 
+    #if swift(>=4.2)
+    public enum ServiceType: String, Codable, Equatable, CaseIterable {
+    #else
     public enum ServiceType: String, Codable {
+    #endif
         case regular = "Regular"
         case night = "Night"
-
+        #if swift(<4.2)
         public static let cases: [ServiceType] = [
           .regular,
           .night,
         ]
+        #endif
     }
 
     /** The id of this branch. */

--- a/Specs/TFL/generated/Swift/Sources/Requests/Journey/JourneyJourneyResults.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Journey/JourneyJourneyResults.swift
@@ -13,38 +13,52 @@ extension TFL.Journey {
         public static let service = APIService<Response>(id: "Journey_JourneyResults", tag: "Journey", method: "GET", path: "/Journey/JourneyResults/{from}/to/{to}", hasBody: false)
 
         /** Does the time given relate to arrival or leaving time? Possible options: "departing" | "arriving" */
+        #if swift(>=4.2)
+        public enum TimeIs: String, Codable, Equatable, CaseIterable {
+        #else
         public enum TimeIs: String, Codable {
+        #endif
             case arriving = "Arriving"
             case departing = "Departing"
-
+            #if swift(<4.2)
             public static let cases: [TimeIs] = [
               .arriving,
               .departing,
             ]
+            #endif
         }
 
         /** The journey preference eg possible options: "leastinterchange" | "leasttime" | "leastwalking" */
+        #if swift(>=4.2)
+        public enum JourneyPreference: String, Codable, Equatable, CaseIterable {
+        #else
         public enum JourneyPreference: String, Codable {
+        #endif
             case leastInterchange = "LeastInterchange"
             case leastTime = "LeastTime"
             case leastWalking = "LeastWalking"
-
+            #if swift(<4.2)
             public static let cases: [JourneyPreference] = [
               .leastInterchange,
               .leastTime,
               .leastWalking,
             ]
+            #endif
         }
 
         /** The accessibility preference must be a comma separated list eg. "noSolidStairs,noEscalators,noElevators,stepFreeToVehicle,stepFreeToPlatform" */
+        #if swift(>=4.2)
+        public enum AccessibilityPreference: String, Codable, Equatable, CaseIterable {
+        #else
         public enum AccessibilityPreference: String, Codable {
+        #endif
             case noRequirements = "NoRequirements"
             case noSolidStairs = "NoSolidStairs"
             case noEscalators = "NoEscalators"
             case noElevators = "NoElevators"
             case stepFreeToVehicle = "StepFreeToVehicle"
             case stepFreeToPlatform = "StepFreeToPlatform"
-
+            #if swift(<4.2)
             public static let cases: [AccessibilityPreference] = [
               .noRequirements,
               .noSolidStairs,
@@ -53,29 +67,39 @@ extension TFL.Journey {
               .stepFreeToVehicle,
               .stepFreeToPlatform,
             ]
+            #endif
         }
 
         /** The walking speed. eg possible options: "slow" | "average" | "fast". */
+        #if swift(>=4.2)
+        public enum WalkingSpeed: String, Codable, Equatable, CaseIterable {
+        #else
         public enum WalkingSpeed: String, Codable {
+        #endif
             case slow = "Slow"
             case average = "Average"
             case fast = "Fast"
-
+            #if swift(<4.2)
             public static let cases: [WalkingSpeed] = [
               .slow,
               .average,
               .fast,
             ]
+            #endif
         }
 
         /** The cycle preference. eg possible options: "allTheWay" | "leaveAtStation" | "takeOnTransport" | "cycleHire" */
+        #if swift(>=4.2)
+        public enum CyclePreference: String, Codable, Equatable, CaseIterable {
+        #else
         public enum CyclePreference: String, Codable {
+        #endif
             case none = "None"
             case leaveAtStation = "LeaveAtStation"
             case takeOnTransport = "TakeOnTransport"
             case allTheWay = "AllTheWay"
             case cycleHire = "CycleHire"
-
+            #if swift(<4.2)
             public static let cases: [CyclePreference] = [
               .none,
               .leaveAtStation,
@@ -83,19 +107,25 @@ extension TFL.Journey {
               .allTheWay,
               .cycleHire,
             ]
+            #endif
         }
 
         /** A comma separated list of cycling proficiency levels. eg possible options: "easy,moderate,fast" */
+        #if swift(>=4.2)
+        public enum BikeProficiency: String, Codable, Equatable, CaseIterable {
+        #else
         public enum BikeProficiency: String, Codable {
+        #endif
             case easy = "Easy"
             case moderate = "Moderate"
             case fast = "Fast"
-
+            #if swift(<4.2)
             public static let cases: [BikeProficiency] = [
               .easy,
               .moderate,
               .fast,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/GetLineArrivalsByPath.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/GetLineArrivalsByPath.swift
@@ -13,16 +13,21 @@ extension TFL.Line {
         public static let service = APIService<Response>(id: "getLineArrivalsByPath", tag: "Line", method: "GET", path: "/Line/{ids}/Arrivals/{stopPointId}", hasBody: false)
 
         /** The direction of travel. Can be inbound or outbound */
+        #if swift(>=4.2)
+        public enum Direction: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Direction: String, Codable {
+        #endif
             case inbound = "inbound"
             case outbound = "outbound"
             case all = "all"
-
+            #if swift(<4.2)
             public static let cases: [Direction] = [
               .inbound,
               .outbound,
               .all,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineLineRoutesByIds.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineLineRoutesByIds.swift
@@ -13,14 +13,19 @@ extension TFL.Line {
         public static let service = APIService<Response>(id: "Line_LineRoutesByIds", tag: "Line", method: "GET", path: "/Line/{ids}/Route", hasBody: false)
 
         /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        #if swift(>=4.2)
+        public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ServiceTypes: String, Codable {
+        #endif
             case regular = "Regular"
             case night = "Night"
-
+            #if swift(<4.2)
             public static let cases: [ServiceTypes] = [
               .regular,
               .night,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRoute.swift
@@ -13,14 +13,19 @@ extension TFL.Line {
         public static let service = APIService<Response>(id: "Line_Route", tag: "Line", method: "GET", path: "/Line/Route", hasBody: false)
 
         /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        #if swift(>=4.2)
+        public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ServiceTypes: String, Codable {
+        #endif
             case regular = "Regular"
             case night = "Night"
-
+            #if swift(<4.2)
             public static let cases: [ServiceTypes] = [
               .regular,
               .night,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteByMode.swift
@@ -13,14 +13,19 @@ extension TFL.Line {
         public static let service = APIService<Response>(id: "Line_RouteByMode", tag: "Line", method: "GET", path: "/Line/Mode/{modes}/Route", hasBody: false)
 
         /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        #if swift(>=4.2)
+        public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ServiceTypes: String, Codable {
+        #endif
             case regular = "Regular"
             case night = "Night"
-
+            #if swift(<4.2)
             public static let cases: [ServiceTypes] = [
               .regular,
               .night,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteSequence.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteSequence.swift
@@ -13,27 +13,37 @@ extension TFL.Line {
         public static let service = APIService<Response>(id: "Line_RouteSequence", tag: "Line", method: "GET", path: "/Line/{id}/Route/Sequence/{direction}", hasBody: false)
 
         /** The direction of travel. Can be inbound or outbound. */
+        #if swift(>=4.2)
+        public enum Direction: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Direction: String, Codable {
+        #endif
             case inbound = "inbound"
             case outbound = "outbound"
             case all = "all"
-
+            #if swift(<4.2)
             public static let cases: [Direction] = [
               .inbound,
               .outbound,
               .all,
             ]
+            #endif
         }
 
         /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        #if swift(>=4.2)
+        public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ServiceTypes: String, Codable {
+        #endif
             case regular = "Regular"
             case night = "Night"
-
+            #if swift(<4.2)
             public static let cases: [ServiceTypes] = [
               .regular,
               .night,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineSearch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineSearch.swift
@@ -13,14 +13,19 @@ extension TFL.Line {
         public static let service = APIService<Response>(id: "Line_Search", tag: "Line", method: "GET", path: "/Line/Search/{query}", hasBody: false)
 
         /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        #if swift(>=4.2)
+        public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ServiceTypes: String, Codable {
+        #endif
             case regular = "Regular"
             case night = "Night"
-
+            #if swift(<4.2)
             public static let cases: [ServiceTypes] = [
               .regular,
               .night,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointCrowding.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointCrowding.swift
@@ -13,16 +13,21 @@ extension TFL.StopPoint {
         public static let service = APIService<Response>(id: "StopPoint_Crowding", tag: "StopPoint", method: "GET", path: "/StopPoint/{id}/Crowding/{line}", hasBody: false)
 
         /** The direction of travel. Can be inbound or outbound. */
+        #if swift(>=4.2)
+        public enum Direction: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Direction: String, Codable {
+        #endif
             case inbound = "inbound"
             case outbound = "outbound"
             case all = "all"
-
+            #if swift(<4.2)
             public static let cases: [Direction] = [
               .inbound,
               .outbound,
               .all,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointReachableFrom.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointReachableFrom.swift
@@ -13,14 +13,19 @@ extension TFL.StopPoint {
         public static let service = APIService<Response>(id: "StopPoint_ReachableFrom", tag: "StopPoint", method: "GET", path: "/StopPoint/{id}/CanReachOnLine/{lineId}", hasBody: false)
 
         /** A comma-separated list of service types to filter on. If not specified. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        #if swift(>=4.2)
+        public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ServiceTypes: String, Codable {
+        #endif
             case regular = "Regular"
             case night = "Night"
-
+            #if swift(<4.2)
             public static let cases: [ServiceTypes] = [
               .regular,
               .night,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointRoute.swift
@@ -13,14 +13,19 @@ extension TFL.StopPoint {
         public static let service = APIService<Response>(id: "StopPoint_Route", tag: "StopPoint", method: "GET", path: "/StopPoint/{id}/Route", hasBody: false)
 
         /** A comma-separated list of service types to filter on. If not specified. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        #if swift(>=4.2)
+        public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
+        #else
         public enum ServiceTypes: String, Codable {
+        #endif
             case regular = "Regular"
             case night = "Night"
-
+            #if swift(<4.2)
             public static let cases: [ServiceTypes] = [
               .regular,
               .night,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/TravelTime/TravelTimeGetCompareOverlay.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/TravelTime/TravelTimeGetCompareOverlay.swift
@@ -13,16 +13,21 @@ extension TFL.TravelTime {
         public static let service = APIService<Response>(id: "TravelTime_GetCompareOverlay", tag: "TravelTime", method: "GET", path: "/TravelTimes/compareOverlay/{z}/mapcenter/{mapCenterLat}/{mapCenterLon}/pinlocation/{pinLat}/{pinLon}/dimensions/{width}/{height}", hasBody: false)
 
         /** The direction of travel. */
+        #if swift(>=4.2)
+        public enum Direction: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Direction: String, Codable {
+        #endif
             case average = "Average"
             case from = "From"
             case to = "To"
-
+            #if swift(<4.2)
             public static let cases: [Direction] = [
               .average,
               .from,
               .to,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TFL/generated/Swift/Sources/Requests/TravelTime/TravelTimeGetOverlay.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/TravelTime/TravelTimeGetOverlay.swift
@@ -13,16 +13,21 @@ extension TFL.TravelTime {
         public static let service = APIService<Response>(id: "TravelTime_GetOverlay", tag: "TravelTime", method: "GET", path: "/TravelTimes/overlay/{z}/mapcenter/{mapCenterLat}/{mapCenterLon}/pinlocation/{pinLat}/{pinLon}/dimensions/{width}/{height}", hasBody: false)
 
         /** The direction of travel. */
+        #if swift(>=4.2)
+        public enum Direction: String, Codable, Equatable, CaseIterable {
+        #else
         public enum Direction: String, Codable {
+        #endif
             case average = "Average"
             case from = "From"
             case to = "To"
-
+            #if swift(<4.2)
             public static let cases: [Direction] = [
               .average,
               .from,
               .to,
             ]
+            #endif
         }
 
         public final class Request: APIRequest<Response> {

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/GetInlineEnumResponse.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/GetInlineEnumResponse.swift
@@ -22,14 +22,19 @@ extension TestSpec {
         public enum Response: APIResponseValue, CustomStringConvertible, CustomDebugStringConvertible {
 
             /** enum response */
+            #if swift(>=4.2)
+            public enum Status200: Int, Codable, Equatable, CaseIterable {
+            #else
             public enum Status200: Int, Codable {
+            #endif
                 case one = 1
                 case two = 2
-
+                #if swift(<4.2)
                 public static let cases: [Status200] = [
                   .one,
                   .two,
                 ]
+                #endif
             }
             public typealias SuccessType = [String: Status200]
 

--- a/Templates/Swift/Includes/Enum.stencil
+++ b/Templates/Swift/Includes/Enum.stencil
@@ -1,14 +1,19 @@
 {% if description %}
 /** {{ description }} */
 {% endif %}
+#if swift(>=4.2)
+public enum {{ enumName }}: {{ type }}, Codable, Equatable, CaseIterable {
+#else
 public enum {{ enumName }}: {{ type }}, Codable {
+#endif
     {% for enumCase in enums %}
     case {{ enumCase.name }} = {% if type == "String" %}"{% endif %}{{enumCase.value}}{% if type == "String" %}"{% endif %}
     {% endfor %}
-
+    #if swift(<4.2)
     public static let cases: [{{ enumName }}] = [
       {% for enumCase in enums %}
       .{{ enumCase.name }},
       {% endfor %}
     ]
+    #endif
 }


### PR DESCRIPTION
Remove old `cases` implementation and replacing it with `CaseIterable`