### PR TITLE
Fix path params with names that differ from swift names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Update `Alamofire` dependency to 4.8.1
 - Update `Result` dependency to 4.1.0
 
+### Fixed
+- Fixed path params that don't have swift friendly names #130
+
 ### Removed
 - Removed support for Swagger 2 #118
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/DeleteOrder.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/DeleteOrder.swift
@@ -42,7 +42,7 @@ extension PetstoreTest.Store {
             }
 
             public override var path: String {
-                return super.path.replacingOccurrences(of: "{" + "orderId" + "}", with: "\(self.options.orderId)")
+                return super.path.replacingOccurrences(of: "{" + "order_id" + "}", with: "\(self.options.orderId)")
             }
         }
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/GetOrderById.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/GetOrderById.swift
@@ -42,7 +42,7 @@ extension PetstoreTest.Store {
             }
 
             public override var path: String {
-                return super.path.replacingOccurrences(of: "{" + "orderId" + "}", with: "\(self.options.orderId)")
+                return super.path.replacingOccurrences(of: "{" + "order_id" + "}", with: "\(self.options.orderId)")
             }
         }
 

--- a/Templates/Swift/Sources/Request.swift
+++ b/Templates/Swift/Sources/Request.swift
@@ -87,7 +87,7 @@ extension {{ options.name }}{% if tag %}.{{ options.tagPrefix }}{{ tag|upperCame
             {% if pathParams %}
 
             public override var path: String {
-                return super.path{% for param in pathParams %}.replacingOccurrences(of: "{" + "{{ param.name }}" + "}", with: "\(self.options.{{ param.encodedValue }})"){% endfor %}
+                return super.path{% for param in pathParams %}.replacingOccurrences(of: "{" + "{{ param.value }}" + "}", with: "\(self.options.{{ param.encodedValue }})"){% endfor %}
             }
             {% endif %}
             {% if queryParams %}


### PR DESCRIPTION
path params like `user_id` were incorrectly being sent as `userId`.
Can't believe no one noticed this before 😄 