### PR TITLE
Undecodable (unknown) enum case option (135)

### DIFF
--- a/Templates/Swift/Includes/Enum.stencil
+++ b/Templates/Swift/Includes/Enum.stencil
@@ -5,4 +5,7 @@ public enum {{ enumName }}: {{ type }}, Codable, Equatable, CaseIterable {
     {% for enumCase in enums %}
     case {{ enumCase.name }} = {% if type == "String" %}"{% endif %}{{enumCase.value}}{% if type == "String" %}"{% endif %}
     {% endfor %}
+    {% if options.enumUndecodableCase %}
+    case undecodable
+    {% endif %}
 }

--- a/Templates/Swift/Includes/Model.stencil
+++ b/Templates/Swift/Includes/Model.stencil
@@ -12,6 +12,9 @@ public enum {{ type }}: Codable, Equatable {
     {% for subType in discriminatorType.subTypes %}
     case {{ subType.name}}({{ subType.type }})
     {% endfor %}
+    {% if options.enumUndecodableCase %}
+    case undecodable
+    {% endif %}
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: StringCodingKey.self)
@@ -22,7 +25,11 @@ public enum {{ type }}: Codable, Equatable {
             self = .{{ subType.name}}(try {{ subType.type }}(from: decoder))
         {% endfor %}
         default:
+        {% if options.enumUndecodableCase %}
+            self = .undecodable
+        {% else %}
             throw DecodingError.dataCorrupted(DecodingError.Context.init(codingPath: decoder.codingPath, debugDescription: "Couldn't find type to decode with discriminator \(discriminator)"))
+        {% endif %}
         }
     }
 
@@ -33,6 +40,10 @@ public enum {{ type }}: Codable, Equatable {
         case .{{ subType.name}}(let content):
             try container.encode(content)
         {% endfor %}
+        {% if options.enumUndecodableCase %}
+        case .undecodable:
+            try container.encode("undecodable")
+        {% endif %}
         }
     }
 }

--- a/Templates/Swift/template.yml
+++ b/Templates/Swift/template.yml
@@ -12,6 +12,7 @@ options:
   modelProtocol: APIModel # the protocol all models conform to
   modelNames: {} # override model type names
   enumNames: {} # override enum type names
+  enumUndecodableCase: false # whether to add undecodable case to enums
   typeAliases:
     ID: UUID
     DateTime: Date


### PR DESCRIPTION
This PR implements the unknown enum case proposal ([135](https://github.com/yonaskolb/SwagGen/issues/135)).

- added a template option to generate an additional enum case, defaults to false
- updated enum and model templates to use the new option
- used name `undecodable` instead of `unknown` as the latter appears to be more common and may clash with actual enum values