### PR TITLE
Feature/requestBodies param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ fixedWidthIntegers | whether to use types like Int32 and Int64 | `Bool` | false
 homepage | homepage in podspec  | `String` | https://github.com/yonaskolb/SwagGen
 modelPrefix | model by adding a prefix and model file name | `String` | null
 modelSuffix | model by adding a suffix and model file name | `String` | null
+modelRequestBodyPrefix | applied to model classes and enums in requestBodies models only | `String` | null
+modelRequestBodySuffix | applied to model classes in requestBodies models only | `String` | null
+modelResponsePrefix | applied to model classes and enums in response models only | `String` | null
+modelResponseSuffix | applied to model classes in response models only | `String` | null
 mutableModels | whether model properties are mutable | `Bool` | true
 modelType | whether each model is a `struct` or `class` | `String` | class
 modelInheritance | whether models use inheritance. Must be false for structs | Bool | true

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -13,8 +13,8 @@ public class CodeFormatter {
     var modelSuffix: String
     var modelRequestBodyPrefix: String
     var modelRequestBodySuffix: String
-    var modelResponcePrefix: String
-    var modelResponceSuffix: String
+    var modelResponsePrefix: String
+    var modelResponseSuffix: String
     var modelInheritance: Bool
     var modelNames: [String: String]
     var enumNames: [String: String]
@@ -26,8 +26,8 @@ public class CodeFormatter {
         modelSuffix = templateConfig.getStringOption("modelSuffix") ?? ""
         modelRequestBodyPrefix = templateConfig.getStringOption("modelRequestBodyPrefix") ?? ""
         modelRequestBodySuffix = templateConfig.getStringOption("modelRequestBodySuffix") ?? ""
-        modelResponcePrefix = templateConfig.getStringOption("modelResponcePrefix") ?? ""
-        modelResponceSuffix = templateConfig.getStringOption("modelResponceSuffix") ?? ""
+        modelResponsePrefix = templateConfig.getStringOption("modelResponsePrefix") ?? ""
+        modelResponseSuffix = templateConfig.getStringOption("modelResponseSuffix") ?? ""
         modelInheritance = templateConfig.getBooleanOption("modelInheritance") ?? true
         modelNames = templateConfig.options["modelNames"] as? [String: String] ?? [:]
         enumNames = templateConfig.options["enumNames"] as? [String: String] ?? [:]
@@ -184,7 +184,7 @@ public class CodeFormatter {
             schema.value.getEnum(name: name, description: schema.value.metadata.description) != nil {
             name = getEnumType(name)
         } else {
-            name = getResponceModelType(name)
+            name = getResponseModelType(name)
             name = getModelType(name)
         }
         
@@ -581,12 +581,12 @@ public class CodeFormatter {
         return escapeType("\(modelRequestBodyPrefix)\(type)\(modelRequestBodySuffix)")
     }
     
-    func getResponceModelType(_ name: String) -> String {
+    func getResponseModelType(_ name: String) -> String {
         if let modelName = modelNames[name] {
             return modelName
         }
         let type = name.upperCamelCased()
-        return escapeType("\(modelResponcePrefix)\(type)\(modelResponceSuffix)")
+        return escapeType("\(modelResponsePrefix)\(type)\(modelResponseSuffix)")
     }
 
     func getSchemaType(name: String, schema: Schema, checkEnum: Bool = true) -> String {

--- a/Templates/Swift/template.yml
+++ b/Templates/Swift/template.yml
@@ -7,6 +7,10 @@ options:
   safeArrayDecoding: false # filter out invalid items in array instead of throwing
   modelPrefix: null # applied to model classes and enums
   modelSuffix: null # applied to model classes
+  modelRequestBodyPrefix: null # applied to model classes and enums in requestBodies models only
+  modelRequestBodySuffix: null # applied to model classes in requestBodies models only
+  modelResponsePrefix: null # applied to model classes and enums in response models only
+  modelResponseSuffix: null # applied to model classes in response models only
   modelType: class # can be struct or class
   modelInheritance: true # must be false for struct modelType
   modelProtocol: APIModel # the protocol all models conform to
@@ -47,8 +51,11 @@ templateFiles:
     context: enums
     destination: "Sources/Enums/{{ enumName }}.swift"
   - path: Sources/Model.swift
+    context: requestBodies
+    destination: "Sources/Models/Request/{{ type }}.swift"
+  - path: Sources/Model.swift
     context: schemas
-    destination: "Sources/Models/{{ type }}.swift"
+    destination: "Sources/Models/Response/{{ type }}.swift"
   - path: Sources/Request.swift
     context: operations
     destination: "Sources/Requests{% if tag %}/{{ tag|upperCamelCase }}{% endif %}/{{ type }}.swift"


### PR DESCRIPTION
This PR implements the requestBodies schemas ([148](https://github.com/yonaskolb/SwagGen/issues/148)).
- Added requestBodies models generation
- Added "name" param for every schema: containts original name, whithout suffixes and prefixes
- Added 4 template params: modelRequestBodyPrefix, modelRequestBodySuffix, modelResponsePrefix, modelResponseSuffix
- Updated template for example requestBodies and new params example
- Updated readme with new prefix and suffix description