### PR TITLE
Update APIClient.swift

### DIFF
--- a/Templates/Swift/Sources/APIClient.swift
+++ b/Templates/Swift/Sources/APIClient.swift
@@ -109,6 +109,8 @@ public class APIClient {
                             multipartFormData.append(url, withName: name)
                         } else if let data = value as? Data {
                             multipartFormData.append(data, withName: name)
+                        } else if let string = value as? String {
+                            multipartFormData.append(Data(string.utf8), withName: name)
                         }
                     }
                 },


### PR DESCRIPTION
Add case for strings in multipart form data.

Without this, our backend was receiving string fields as part of multiform data.