### PR TITLE
Remove Result framework and use Swift.Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added support for objects in query params
 - Added support for nullable properties
 
+### Changed:
+- Remove Result 3rd party framework
+
 ## 4.1.0
 
 ### Added

--- a/Specs/Petstore/generated/Swift/Cartfile
+++ b/Specs/Petstore/generated/Swift/Cartfile
@@ -1,3 +1,2 @@
 
 github "Alamofire/Alamofire" ~> 4.8.2
-github "antitypical/Result" ~> 4.1.0

--- a/Specs/Petstore/generated/Swift/Package.swift
+++ b/Specs/Petstore/generated/Swift/Package.swift
@@ -9,12 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .exact("4.8.2")),
-        .package(url: "https://github.com/antitypical/Result.git", .exact("4.1.0")),
     ],
     targets: [
         .target(name: "Petstore", dependencies: [
           "Alamofire",
-          "Result",
         ], path: "Sources")
     ]
 )

--- a/Specs/Petstore/generated/Swift/Petstore.podspec
+++ b/Specs/Petstore/generated/Swift/Petstore.podspec
@@ -11,5 +11,4 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = '10.9'
     s.source_files = 'Sources/**/*.swift'
     s.dependency 'Alamofire', '~> 4.8.2'
-    s.dependency 'Result', '~> 4.1.0'
 end

--- a/Specs/Petstore/generated/Swift/Sources/APIResponse.swift
+++ b/Specs/Petstore/generated/Swift/Sources/APIResponse.swift
@@ -91,7 +91,7 @@ extension APIResponse: CustomStringConvertible, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         var string = description
-        if let response = result.value?.response {
+        if let response = try? result.get().response {
           if let debugStringConvertible = response as? CustomDebugStringConvertible {
               string += "\n\(debugStringConvertible.debugDescription)"
           }

--- a/Specs/Petstore/generated/Swift/Sources/APIResult.swift
+++ b/Specs/Petstore/generated/Swift/Sources/APIResult.swift
@@ -3,6 +3,4 @@
 // https://github.com/yonaskolb/SwagGen
 //
 
-import Result
-
 public typealias APIResult<T> = Result<T, APIClientError>

--- a/Specs/PetstoreTest/generated/Swift/Cartfile
+++ b/Specs/PetstoreTest/generated/Swift/Cartfile
@@ -1,3 +1,2 @@
 
 github "Alamofire/Alamofire" ~> 4.8.2
-github "antitypical/Result" ~> 4.1.0

--- a/Specs/PetstoreTest/generated/Swift/Package.swift
+++ b/Specs/PetstoreTest/generated/Swift/Package.swift
@@ -9,12 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .exact("4.8.2")),
-        .package(url: "https://github.com/antitypical/Result.git", .exact("4.1.0")),
     ],
     targets: [
         .target(name: "PetstoreTest", dependencies: [
           "Alamofire",
-          "Result",
         ], path: "Sources")
     ]
 )

--- a/Specs/PetstoreTest/generated/Swift/PetstoreTest.podspec
+++ b/Specs/PetstoreTest/generated/Swift/PetstoreTest.podspec
@@ -11,5 +11,4 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = '10.9'
     s.source_files = 'Sources/**/*.swift'
     s.dependency 'Alamofire', '~> 4.8.2'
-    s.dependency 'Result', '~> 4.1.0'
 end

--- a/Specs/PetstoreTest/generated/Swift/Sources/APIResponse.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/APIResponse.swift
@@ -91,7 +91,7 @@ extension APIResponse: CustomStringConvertible, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         var string = description
-        if let response = result.value?.response {
+        if let response = try? result.get().response {
           if let debugStringConvertible = response as? CustomDebugStringConvertible {
               string += "\n\(debugStringConvertible.debugDescription)"
           }

--- a/Specs/PetstoreTest/generated/Swift/Sources/APIResult.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/APIResult.swift
@@ -3,6 +3,4 @@
 // https://github.com/yonaskolb/SwagGen
 //
 
-import Result
-
 public typealias APIResult<T> = Result<T, APIClientError>

--- a/Specs/Rocket/generated/Swift/Cartfile
+++ b/Specs/Rocket/generated/Swift/Cartfile
@@ -1,3 +1,2 @@
 
 github "Alamofire/Alamofire" ~> 4.8.2
-github "antitypical/Result" ~> 4.1.0

--- a/Specs/Rocket/generated/Swift/Package.swift
+++ b/Specs/Rocket/generated/Swift/Package.swift
@@ -9,12 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .exact("4.8.2")),
-        .package(url: "https://github.com/antitypical/Result.git", .exact("4.1.0")),
     ],
     targets: [
         .target(name: "Rocket", dependencies: [
           "Alamofire",
-          "Result",
         ], path: "Sources")
     ]
 )

--- a/Specs/Rocket/generated/Swift/Rocket.podspec
+++ b/Specs/Rocket/generated/Swift/Rocket.podspec
@@ -15,5 +15,4 @@ best suits the application they are developing.
     s.osx.deployment_target = '10.9'
     s.source_files = 'Sources/**/*.swift'
     s.dependency 'Alamofire', '~> 4.8.2'
-    s.dependency 'Result', '~> 4.1.0'
 end

--- a/Specs/Rocket/generated/Swift/Sources/APIResponse.swift
+++ b/Specs/Rocket/generated/Swift/Sources/APIResponse.swift
@@ -91,7 +91,7 @@ extension APIResponse: CustomStringConvertible, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         var string = description
-        if let response = result.value?.response {
+        if let response = try? result.get().response {
           if let debugStringConvertible = response as? CustomDebugStringConvertible {
               string += "\n\(debugStringConvertible.debugDescription)"
           }

--- a/Specs/Rocket/generated/Swift/Sources/APIResult.swift
+++ b/Specs/Rocket/generated/Swift/Sources/APIResult.swift
@@ -3,6 +3,4 @@
 // https://github.com/yonaskolb/SwagGen
 //
 
-import Result
-
 public typealias APIResult<T> = Result<T, APIClientError>

--- a/Specs/TBX/generated/Swift/Cartfile
+++ b/Specs/TBX/generated/Swift/Cartfile
@@ -1,3 +1,2 @@
 
 github "Alamofire/Alamofire" ~> 4.8.2
-github "antitypical/Result" ~> 4.1.0

--- a/Specs/TBX/generated/Swift/Package.swift
+++ b/Specs/TBX/generated/Swift/Package.swift
@@ -9,12 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .exact("4.8.2")),
-        .package(url: "https://github.com/antitypical/Result.git", .exact("4.1.0")),
     ],
     targets: [
         .target(name: "TBX", dependencies: [
           "Alamofire",
-          "Result",
         ], path: "Sources")
     ]
 )

--- a/Specs/TBX/generated/Swift/Sources/APIResponse.swift
+++ b/Specs/TBX/generated/Swift/Sources/APIResponse.swift
@@ -91,7 +91,7 @@ extension APIResponse: CustomStringConvertible, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         var string = description
-        if let response = result.value?.response {
+        if let response = try? result.get().response {
           if let debugStringConvertible = response as? CustomDebugStringConvertible {
               string += "\n\(debugStringConvertible.debugDescription)"
           }

--- a/Specs/TBX/generated/Swift/Sources/APIResult.swift
+++ b/Specs/TBX/generated/Swift/Sources/APIResult.swift
@@ -3,6 +3,4 @@
 // https://github.com/yonaskolb/SwagGen
 //
 
-import Result
-
 public typealias APIResult<T> = Result<T, APIClientError>

--- a/Specs/TBX/generated/Swift/TBX.podspec
+++ b/Specs/TBX/generated/Swift/TBX.podspec
@@ -11,5 +11,4 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = '10.9'
     s.source_files = 'Sources/**/*.swift'
     s.dependency 'Alamofire', '~> 4.8.2'
-    s.dependency 'Result', '~> 4.1.0'
 end

--- a/Specs/TFL/generated/Swift/Cartfile
+++ b/Specs/TFL/generated/Swift/Cartfile
@@ -1,3 +1,2 @@
 
 github "Alamofire/Alamofire" ~> 4.8.2
-github "antitypical/Result" ~> 4.1.0

--- a/Specs/TFL/generated/Swift/Package.swift
+++ b/Specs/TFL/generated/Swift/Package.swift
@@ -9,12 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .exact("4.8.2")),
-        .package(url: "https://github.com/antitypical/Result.git", .exact("4.1.0")),
     ],
     targets: [
         .target(name: "TFL", dependencies: [
           "Alamofire",
-          "Result",
         ], path: "Sources")
     ]
 )

--- a/Specs/TFL/generated/Swift/Sources/APIResponse.swift
+++ b/Specs/TFL/generated/Swift/Sources/APIResponse.swift
@@ -91,7 +91,7 @@ extension APIResponse: CustomStringConvertible, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         var string = description
-        if let response = result.value?.response {
+        if let response = try? result.get().response {
           if let debugStringConvertible = response as? CustomDebugStringConvertible {
               string += "\n\(debugStringConvertible.debugDescription)"
           }

--- a/Specs/TFL/generated/Swift/Sources/APIResult.swift
+++ b/Specs/TFL/generated/Swift/Sources/APIResult.swift
@@ -3,6 +3,4 @@
 // https://github.com/yonaskolb/SwagGen
 //
 
-import Result
-
 public typealias APIResult<T> = Result<T, APIClientError>

--- a/Specs/TFL/generated/Swift/TFL.podspec
+++ b/Specs/TFL/generated/Swift/TFL.podspec
@@ -11,5 +11,4 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = '10.9'
     s.source_files = 'Sources/**/*.swift'
     s.dependency 'Alamofire', '~> 4.8.2'
-    s.dependency 'Result', '~> 4.1.0'
 end

--- a/Specs/TestSpec/generated/Swift/Cartfile
+++ b/Specs/TestSpec/generated/Swift/Cartfile
@@ -1,3 +1,2 @@
 
 github "Alamofire/Alamofire" ~> 4.8.2
-github "antitypical/Result" ~> 4.1.0

--- a/Specs/TestSpec/generated/Swift/Package.swift
+++ b/Specs/TestSpec/generated/Swift/Package.swift
@@ -9,12 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .exact("4.8.2")),
-        .package(url: "https://github.com/antitypical/Result.git", .exact("4.1.0")),
     ],
     targets: [
         .target(name: "TestSpec", dependencies: [
           "Alamofire",
-          "Result",
         ], path: "Sources")
     ]
 )

--- a/Specs/TestSpec/generated/Swift/Sources/APIResponse.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/APIResponse.swift
@@ -91,7 +91,7 @@ extension APIResponse: CustomStringConvertible, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         var string = description
-        if let response = result.value?.response {
+        if let response = try? result.get().response {
           if let debugStringConvertible = response as? CustomDebugStringConvertible {
               string += "\n\(debugStringConvertible.debugDescription)"
           }

--- a/Specs/TestSpec/generated/Swift/Sources/APIResult.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/APIResult.swift
@@ -3,6 +3,4 @@
 // https://github.com/yonaskolb/SwagGen
 //
 
-import Result
-
 public typealias APIResult<T> = Result<T, APIClientError>

--- a/Specs/TestSpec/generated/Swift/TestSpec.podspec
+++ b/Specs/TestSpec/generated/Swift/TestSpec.podspec
@@ -11,5 +11,4 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = '10.9'
     s.source_files = 'Sources/**/*.swift'
     s.dependency 'Alamofire', '~> 4.8.2'
-    s.dependency 'Result', '~> 4.1.0'
 end

--- a/Templates/Swift/Sources/APIResponse.swift
+++ b/Templates/Swift/Sources/APIResponse.swift
@@ -88,7 +88,7 @@ extension APIResponse: CustomStringConvertible, CustomDebugStringConvertible {
 
     public var debugDescription: String {
         var string = description
-        if let response = result.value?.response {
+        if let response = try? result.get().response {
           if let debugStringConvertible = response as? CustomDebugStringConvertible {
               string += "\n\(debugStringConvertible.debugDescription)"
           }

--- a/Templates/Swift/Sources/APIResult.swift
+++ b/Templates/Swift/Sources/APIResult.swift
@@ -1,5 +1,3 @@
 {% include "Includes/Header.stencil" %}
 
-import Result
-
 public typealias APIResult<T> = Result<T, APIClientError>

--- a/Templates/Swift/template.yml
+++ b/Templates/Swift/template.yml
@@ -22,10 +22,6 @@ options:
       pod: Alamofire
       github: Alamofire/Alamofire
       version: 4.8.2
-    - name: Result
-      pod: Result
-      github: antitypical/Result
-      version: 4.1.0
 templateFiles:
   - path: README.md
   - path: Package.swift


### PR DESCRIPTION
### Description
This PR introduces the following changes:
* Remove third party framework _Result_ and use the Swift.Result type