### PR TITLE
Sort operations by path and then method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 ## Next Version
 
+### Changes
+- List operations by path and then by method to keep the order consistent between code generations #185
+
 ### Fixes
 - Fixed responses from silently failing to parse when missing a `description`, which is now an optional property that defaults to an empty string #193
 - Add missing custom model protocol name #191

--- a/Sources/Swagger/SwaggerSpec.swift
+++ b/Sources/Swagger/SwaggerSpec.swift
@@ -99,6 +99,12 @@ extension SwaggerSpec: JSONObjectConvertible {
         }
         paths = try decodeNamed(jsonDictionary: jsonDictionary, key: "paths")
         operations = paths.reduce([]) { $0 + $1.operations }
+            .sorted(by: { (lhs, rhs) -> Bool in
+                if lhs.path == rhs.path {
+                    return lhs.method.rawValue < rhs.method.rawValue
+                }
+                return lhs.path < rhs.path
+            })
 
         let resolver = ComponentResolver(spec: self)
         resolver.resolve()


### PR DESCRIPTION
When listing operations, it's better to have operations always  in the same order to prevent generated code to change from one generation to the other with the same input.
So this introduces the sorting of operations first by `path` and then by `method`.