### PR TITLE
Add missing custom model protocol name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 ## Next Version
 
+### Fixes
+- Add missing custom model protocol name #191
+
 ## 4.2.0
 
 ### Swift Template Changes

--- a/Templates/Swift/Sources/Coding.swift
+++ b/Templates/Swift/Sources/Coding.swift
@@ -17,7 +17,7 @@ public protocol ResponseDecoder {
 
 extension JSONDecoder: ResponseDecoder {}
 
-extension APIModel {
+extension {{ options.modelProtocol }} {
     func encode() -> [String: Any] {
         guard
             let jsonData = try? JSONEncoder().encode(self),


### PR DESCRIPTION
Setting the `modelProtocol` option in the `template.yml` will file will not update the name of an extension