### PR TITLE
Add support for overriding property names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Changes
 - List operations by path and then by method to keep the order consistent between code generations #185
+- Add `propertyNames` option that allow to override the name of properties #196
 
 ### Fixes
 - Fixed responses from silently failing to parse when missing a `description`, which is now an optional property that defaults to an empty string #193

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ modelNames | override model names | `[String: String]` | [:]
 modelProtocol | customize protocol name that all models conform to | `String` | APIModel
 enumNames | override enum names | `[String: String]` | [:]
 enumUndecodableCase | whether to add undecodable case to enums | `Bool` | false
+propertyNames | override property names | `[String: String]` | [:]
 safeArrayDecoding | filter out invalid items in array instead of throwing | `Bool` | false
 safeOptionalDecoding | set invalid optionals to nil instead of throwing | `Bool` | false
 tagPrefix | prefix for all tags | `String` | null

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -421,13 +421,7 @@ public class CodeFormatter {
 
         context["required"] = property.required
         context["optional"] = !property.required || property.schema.metadata.nullable
-      
-        var name = getName(property.name)
-        if let propertyName = propertyNames[name] {
-          name = propertyName
-        }
-        context["name"] = name
-      
+        context["name"] = propertyNames[property.name] ?? getName(property.name)      
         context["value"] = property.name
         context["type"] = getSchemaType(name: property.name, schema: property.schema)
 

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -14,6 +14,7 @@ public class CodeFormatter {
     var modelInheritance: Bool
     var modelNames: [String: String]
     var enumNames: [String: String]
+    var propertyNames: [String: String]
 
     public init(spec: SwaggerSpec, templateConfig: TemplateConfig) {
         self.spec = spec
@@ -23,6 +24,7 @@ public class CodeFormatter {
         modelInheritance = templateConfig.getBooleanOption("modelInheritance") ?? true
         modelNames = templateConfig.options["modelNames"] as? [String: String] ?? [:]
         enumNames = templateConfig.options["enumNames"] as? [String: String] ?? [:]
+        propertyNames = templateConfig.options["propertyNames"] as? [String: String] ?? [:]
     }
 
     var disallowedNames: [String] {
@@ -419,7 +421,13 @@ public class CodeFormatter {
 
         context["required"] = property.required
         context["optional"] = !property.required || property.schema.metadata.nullable
-        context["name"] = getName(property.name)
+      
+        var name = getName(property.name)
+        if let propertyName = propertyNames[name] {
+          name = propertyName
+        }
+        context["name"] = name
+      
         context["value"] = property.name
         context["type"] = getSchemaType(name: property.name, schema: property.schema)
 

--- a/Templates/Swift/template.yml
+++ b/Templates/Swift/template.yml
@@ -13,6 +13,7 @@ options:
   modelNames: {} # override model type names
   enumNames: {} # override enum type names
   enumUndecodableCase: false # whether to add undecodable case to enums
+  propertyNames: {} # override property names
   typeAliases:
     ID: UUID
     DateTime: Date


### PR DESCRIPTION
This feature is analog to `modelNames` and `enumNames` but for property.
I have a case where some property have the name `id` and it conflict.

This feature enable me to define proterty that are called `id` as `_id`.