### PR TITLE
Add Request encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ### Added
 - Added ability to set nested template options from the command line using dot syntax eg `--option "typeAliases.ID: String"` #189
-- Added support for changing default JSON encoder #172
-- Added support for using a custom JSON encoder per request #172
+- Added a customizable `jsonEncoder` on APIClient #172 #203
+- Added support for using a custom encoder per request #172 #203
 
 ### Changes
 - List operations by path and then by method to keep the order consistent between code generations #185

--- a/Specs/Petstore/generated/Swift/Sources/API.swift
+++ b/Specs/Petstore/generated/Swift/Sources/API.swift
@@ -16,14 +16,6 @@ public struct Petstore {
     /// Used to encode Dates when uses as string params
     public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
 
-    /// Default JSONEncoder used to enconde each API request
-    public static var defaultJSONEncoder: JSONEncoder {
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .formatted(Petstore.dateEncodingFormatter)
-
-        return jsonEncoder
-    }
-
     public static let version = "1.0.0"
 
     public enum Pets {}

--- a/Specs/Petstore/generated/Swift/Sources/APIClient.swift
+++ b/Specs/Petstore/generated/Swift/Sources/APIClient.swift
@@ -24,6 +24,7 @@ public class APIClient {
     public var defaultHeaders: [String: String]
 
     public var jsonDecoder = JSONDecoder()
+    public var jsonEncoder = JSONEncoder()
 
     public var decodingQueue = DispatchQueue(label: "apiClient", qos: .utility, attributes: .concurrent)
 
@@ -33,6 +34,7 @@ public class APIClient {
         self.behaviours = behaviours
         self.defaultHeaders = defaultHeaders
         jsonDecoder.dateDecodingStrategy = .custom(dateDecoder)
+        jsonEncoder.dateEncodingStrategy = .formatted(Petstore.dateEncodingFormatter)
     }
 
     /// Makes a network request
@@ -51,7 +53,7 @@ public class APIClient {
         // create the url request from the request
         var urlRequest: URLRequest
         do {
-            urlRequest = try request.createURLRequest(baseURL: baseURL)
+            urlRequest = try request.createURLRequest(baseURL: baseURL, encoder: jsonEncoder)
         } catch {
             let error = APIClientError.requestEncodingError(error)
             requestBehaviour.onFailure(error: error)
@@ -213,7 +215,7 @@ extension APIRequest {
 extension APIRequest {
 
     /// pass in an optional baseURL, otherwise URLRequest.url will be relative
-    public func createURLRequest(baseURL: String = "") throws -> URLRequest {
+    public func createURLRequest(baseURL: String = "", encoder: RequestEncoder = JSONEncoder()) throws -> URLRequest {
         let url = URL(string: "\(baseURL)\(path)")!
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = service.method
@@ -240,7 +242,7 @@ extension APIRequest {
             urlRequest = try URLEncoding.httpBody.encode(urlRequest, with: formParams)
         }
         if let encodeBody = encodeBody {
-            urlRequest.httpBody = try encodeBody()
+            urlRequest.httpBody = try encodeBody(encoder)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
         return urlRequest

--- a/Specs/Petstore/generated/Swift/Sources/APIRequest.swift
+++ b/Specs/Petstore/generated/Swift/Sources/APIRequest.swift
@@ -10,7 +10,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
     public let service: APIService<ResponseType>
     public private(set) var queryParameters: [String: Any]
     public private(set) var formParameters: [String: Any]
-    public let encodeBody: (() throws -> Data)?
+    public let encodeBody: ((RequestEncoder) throws -> Data)?
     private(set) var headerParameters: [String: String]
     public var customHeaders: [String: String] = [:]
 
@@ -26,7 +26,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
                 queryParameters: [String: Any] = [:], 
                 formParameters: [String: Any] = [:],
                 headers: [String: String] = [:], 
-                encodeBody: (() throws -> Data)? = nil) {
+                encodeBody: ((RequestEncoder) throws -> Data)? = nil) {
         self.service = service
         self.queryParameters = queryParameters
         self.formParameters = formParameters
@@ -51,7 +51,7 @@ extension APIRequest: CustomDebugStringConvertible {
     public var debugDescription: String {
         var string = description
         if let encodeBody = encodeBody,
-            let data = try? encodeBody(),
+            let data = try? encodeBody(JSONEncoder()),
             let bodyString = String(data: data, encoding: .utf8) {
             string += "\nbody: \(bodyString)"
         }

--- a/Specs/Petstore/generated/Swift/Sources/Coding.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Coding.swift
@@ -18,6 +18,13 @@ public protocol ResponseDecoder {
 
 extension JSONDecoder: ResponseDecoder {}
 
+public protocol RequestEncoder {
+
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+extension JSONEncoder: RequestEncoder {}
+
 extension APIModel {
     func encode() -> [String: Any] {
         guard

--- a/Specs/PetstoreTest/generated/Swift/Sources/API.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/API.swift
@@ -17,14 +17,6 @@ public struct PetstoreTest {
     /// Used to encode Dates when uses as string params
     public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
 
-    /// Default JSONEncoder used to enconde each API request
-    public static var defaultJSONEncoder: JSONEncoder {
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .formatted(PetstoreTest.dateEncodingFormatter)
-
-        return jsonEncoder
-    }
-
     public static let version = "1.0.0"
 
     public enum Fake {}

--- a/Specs/PetstoreTest/generated/Swift/Sources/APIClient.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/APIClient.swift
@@ -24,6 +24,7 @@ public class APIClient {
     public var defaultHeaders: [String: String]
 
     public var jsonDecoder = JSONDecoder()
+    public var jsonEncoder = JSONEncoder()
 
     public var decodingQueue = DispatchQueue(label: "apiClient", qos: .utility, attributes: .concurrent)
 
@@ -33,6 +34,7 @@ public class APIClient {
         self.behaviours = behaviours
         self.defaultHeaders = defaultHeaders
         jsonDecoder.dateDecodingStrategy = .custom(dateDecoder)
+        jsonEncoder.dateEncodingStrategy = .formatted(PetstoreTest.dateEncodingFormatter)
     }
 
     /// Makes a network request
@@ -51,7 +53,7 @@ public class APIClient {
         // create the url request from the request
         var urlRequest: URLRequest
         do {
-            urlRequest = try request.createURLRequest(baseURL: baseURL)
+            urlRequest = try request.createURLRequest(baseURL: baseURL, encoder: jsonEncoder)
         } catch {
             let error = APIClientError.requestEncodingError(error)
             requestBehaviour.onFailure(error: error)
@@ -213,7 +215,7 @@ extension APIRequest {
 extension APIRequest {
 
     /// pass in an optional baseURL, otherwise URLRequest.url will be relative
-    public func createURLRequest(baseURL: String = "") throws -> URLRequest {
+    public func createURLRequest(baseURL: String = "", encoder: RequestEncoder = JSONEncoder()) throws -> URLRequest {
         let url = URL(string: "\(baseURL)\(path)")!
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = service.method
@@ -240,7 +242,7 @@ extension APIRequest {
             urlRequest = try URLEncoding.httpBody.encode(urlRequest, with: formParams)
         }
         if let encodeBody = encodeBody {
-            urlRequest.httpBody = try encodeBody()
+            urlRequest.httpBody = try encodeBody(encoder)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
         return urlRequest

--- a/Specs/PetstoreTest/generated/Swift/Sources/APIRequest.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/APIRequest.swift
@@ -10,7 +10,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
     public let service: APIService<ResponseType>
     public private(set) var queryParameters: [String: Any]
     public private(set) var formParameters: [String: Any]
-    public let encodeBody: (() throws -> Data)?
+    public let encodeBody: ((RequestEncoder) throws -> Data)?
     private(set) var headerParameters: [String: String]
     public var customHeaders: [String: String] = [:]
 
@@ -26,7 +26,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
                 queryParameters: [String: Any] = [:], 
                 formParameters: [String: Any] = [:],
                 headers: [String: String] = [:], 
-                encodeBody: (() throws -> Data)? = nil) {
+                encodeBody: ((RequestEncoder) throws -> Data)? = nil) {
         self.service = service
         self.queryParameters = queryParameters
         self.formParameters = formParameters
@@ -51,7 +51,7 @@ extension APIRequest: CustomDebugStringConvertible {
     public var debugDescription: String {
         var string = description
         if let encodeBody = encodeBody,
-            let data = try? encodeBody(),
+            let data = try? encodeBody(JSONEncoder()),
             let bodyString = String(data: data, encoding: .utf8) {
             string += "\nbody: \(bodyString)"
         }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
@@ -18,6 +18,13 @@ public protocol ResponseDecoder {
 
 extension JSONDecoder: ResponseDecoder {}
 
+public protocol RequestEncoder {
+
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+extension JSONEncoder: RequestEncoder {}
+
 extension APIModel {
     func encode() -> [String: Any] {
         guard

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestClientModel.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestClientModel.swift
@@ -16,10 +16,10 @@ extension PetstoreTest.Fake {
 
             public var body: Client
 
-            public init(body: Client, jsonEncoder: JSONEncoder = PetstoreTest.defaultJSONEncoder) {
+            public init(body: Client, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: TestClientModel.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: TestClientModel.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/AddPet.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/AddPet.swift
@@ -16,10 +16,10 @@ extension PetstoreTest.Pet {
 
             public var body: Pet
 
-            public init(body: Pet, jsonEncoder: JSONEncoder = PetstoreTest.defaultJSONEncoder) {
+            public init(body: Pet, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: AddPet.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: AddPet.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/UpdatePet.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Pet/UpdatePet.swift
@@ -16,10 +16,10 @@ extension PetstoreTest.Pet {
 
             public var body: Pet
 
-            public init(body: Pet, jsonEncoder: JSONEncoder = PetstoreTest.defaultJSONEncoder) {
+            public init(body: Pet, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: UpdatePet.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: UpdatePet.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/PlaceOrder.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Store/PlaceOrder.swift
@@ -16,10 +16,10 @@ extension PetstoreTest.Store {
 
             public var body: Order
 
-            public init(body: Order, jsonEncoder: JSONEncoder = PetstoreTest.defaultJSONEncoder) {
+            public init(body: Order, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: PlaceOrder.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: PlaceOrder.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUser.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUser.swift
@@ -20,10 +20,10 @@ extension PetstoreTest.User {
 
             public var body: User
 
-            public init(body: User, jsonEncoder: JSONEncoder = PetstoreTest.defaultJSONEncoder) {
+            public init(body: User, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: CreateUser.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: CreateUser.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUsersWithArrayInput.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUsersWithArrayInput.swift
@@ -16,10 +16,10 @@ extension PetstoreTest.User {
 
             public var body: [User]
 
-            public init(body: [User], jsonEncoder: JSONEncoder = PetstoreTest.defaultJSONEncoder) {
+            public init(body: [User], encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: CreateUsersWithArrayInput.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: CreateUsersWithArrayInput.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUsersWithListInput.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/CreateUsersWithListInput.swift
@@ -16,10 +16,10 @@ extension PetstoreTest.User {
 
             public var body: [User]
 
-            public init(body: [User], jsonEncoder: JSONEncoder = PetstoreTest.defaultJSONEncoder) {
+            public init(body: [User], encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: CreateUsersWithListInput.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: CreateUsersWithListInput.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/UpdateUser.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/User/UpdateUser.swift
@@ -32,11 +32,11 @@ extension PetstoreTest.User {
 
             public var body: User
 
-            public init(body: User, options: Options, jsonEncoder: JSONEncoder = PetstoreTest.defaultJSONEncoder) {
+            public init(body: User, options: Options, encoder: RequestEncoder? = nil) {
                 self.body = body
                 self.options = options
-                super.init(service: UpdateUser.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: UpdateUser.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
 

--- a/Specs/Rocket/generated/Swift/Sources/API.swift
+++ b/Specs/Rocket/generated/Swift/Sources/API.swift
@@ -21,14 +21,6 @@ public struct Rocket {
     /// Used to encode Dates when uses as string params
     public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
 
-    /// Default JSONEncoder used to enconde each API request
-    public static var defaultJSONEncoder: JSONEncoder {
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .formatted(Rocket.dateEncodingFormatter)
-
-        return jsonEncoder
-    }
-
     public static let version = "1.0.0"
 
     public enum Account {}

--- a/Specs/Rocket/generated/Swift/Sources/APIClient.swift
+++ b/Specs/Rocket/generated/Swift/Sources/APIClient.swift
@@ -24,6 +24,7 @@ public class APIClient {
     public var defaultHeaders: [String: String]
 
     public var jsonDecoder = JSONDecoder()
+    public var jsonEncoder = JSONEncoder()
 
     public var decodingQueue = DispatchQueue(label: "apiClient", qos: .utility, attributes: .concurrent)
 
@@ -33,6 +34,7 @@ public class APIClient {
         self.behaviours = behaviours
         self.defaultHeaders = defaultHeaders
         jsonDecoder.dateDecodingStrategy = .custom(dateDecoder)
+        jsonEncoder.dateEncodingStrategy = .formatted(Rocket.dateEncodingFormatter)
     }
 
     /// Makes a network request
@@ -51,7 +53,7 @@ public class APIClient {
         // create the url request from the request
         var urlRequest: URLRequest
         do {
-            urlRequest = try request.createURLRequest(baseURL: baseURL)
+            urlRequest = try request.createURLRequest(baseURL: baseURL, encoder: jsonEncoder)
         } catch {
             let error = APIClientError.requestEncodingError(error)
             requestBehaviour.onFailure(error: error)
@@ -213,7 +215,7 @@ extension APIRequest {
 extension APIRequest {
 
     /// pass in an optional baseURL, otherwise URLRequest.url will be relative
-    public func createURLRequest(baseURL: String = "") throws -> URLRequest {
+    public func createURLRequest(baseURL: String = "", encoder: RequestEncoder = JSONEncoder()) throws -> URLRequest {
         let url = URL(string: "\(baseURL)\(path)")!
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = service.method
@@ -240,7 +242,7 @@ extension APIRequest {
             urlRequest = try URLEncoding.httpBody.encode(urlRequest, with: formParams)
         }
         if let encodeBody = encodeBody {
-            urlRequest.httpBody = try encodeBody()
+            urlRequest.httpBody = try encodeBody(encoder)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
         return urlRequest

--- a/Specs/Rocket/generated/Swift/Sources/APIRequest.swift
+++ b/Specs/Rocket/generated/Swift/Sources/APIRequest.swift
@@ -10,7 +10,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
     public let service: APIService<ResponseType>
     public private(set) var queryParameters: [String: Any]
     public private(set) var formParameters: [String: Any]
-    public let encodeBody: (() throws -> Data)?
+    public let encodeBody: ((RequestEncoder) throws -> Data)?
     private(set) var headerParameters: [String: String]
     public var customHeaders: [String: String] = [:]
 
@@ -26,7 +26,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
                 queryParameters: [String: Any] = [:], 
                 formParameters: [String: Any] = [:],
                 headers: [String: String] = [:], 
-                encodeBody: (() throws -> Data)? = nil) {
+                encodeBody: ((RequestEncoder) throws -> Data)? = nil) {
         self.service = service
         self.queryParameters = queryParameters
         self.formParameters = formParameters
@@ -51,7 +51,7 @@ extension APIRequest: CustomDebugStringConvertible {
     public var debugDescription: String {
         var string = description
         if let encodeBody = encodeBody,
-            let data = try? encodeBody(),
+            let data = try? encodeBody(JSONEncoder()),
             let bodyString = String(data: data, encoding: .utf8) {
             string += "\nbody: \(bodyString)"
         }

--- a/Specs/Rocket/generated/Swift/Sources/Coding.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Coding.swift
@@ -18,6 +18,13 @@ public protocol ResponseDecoder {
 
 extension JSONDecoder: ResponseDecoder {}
 
+public protocol RequestEncoder {
+
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+extension JSONEncoder: RequestEncoder {}
+
 extension APIModel {
     func encode() -> [String: Any] {
         guard

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/ChangePassword.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/ChangePassword.swift
@@ -16,10 +16,10 @@ extension Rocket.Account {
 
             public var body: ChangePasswordRequest
 
-            public init(body: ChangePasswordRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: ChangePasswordRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: ChangePassword.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: ChangePassword.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/ChangePin.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/ChangePin.swift
@@ -16,10 +16,10 @@ extension Rocket.Account {
 
             public var body: ChangePinRequest
 
-            public init(body: ChangePinRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: ChangePinRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: ChangePin.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: ChangePin.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/CreateProfile.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/CreateProfile.swift
@@ -16,10 +16,10 @@ extension Rocket.Account {
 
             public var body: ProfileCreationRequest
 
-            public init(body: ProfileCreationRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: ProfileCreationRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: CreateProfile.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: CreateProfile.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/RegisterDevice.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/RegisterDevice.swift
@@ -18,10 +18,10 @@ If a device with the same id already exists a `409` conflict will be returned.
 
             public var body: DeviceRegistrationRequest
 
-            public init(body: DeviceRegistrationRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: DeviceRegistrationRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: RegisterDevice.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: RegisterDevice.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateAccount.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateAccount.swift
@@ -18,10 +18,10 @@ This supports partial updates so you can send just the properties you wish to up
 
             public var body: AccountUpdateRequest
 
-            public init(body: AccountUpdateRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: AccountUpdateRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: UpdateAccount.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: UpdateAccount.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateProfileWithId.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Account/UpdateProfileWithId.swift
@@ -30,11 +30,11 @@ This supports partial updates so you can send just the properties you wish to up
 
             public var body: ProfileUpdateRequest
 
-            public init(body: ProfileUpdateRequest, options: Options, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: ProfileUpdateRequest, options: Options, encoder: RequestEncoder? = nil) {
                 self.body = body
                 self.options = options
-                super.init(service: UpdateProfileWithId.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: UpdateProfileWithId.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
 

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetAccountToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetAccountToken.swift
@@ -32,10 +32,10 @@ If neither a pin or password are supplied an http 400 error will be returned.
 
             public var body: AccountTokenRequest
 
-            public init(body: AccountTokenRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: AccountTokenRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: GetAccountToken.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: GetAccountToken.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetProfileToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/GetProfileToken.swift
@@ -20,10 +20,10 @@ before access is granted.
 
             public var body: ProfileTokenRequest
 
-            public init(body: ProfileTokenRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: ProfileTokenRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: GetProfileToken.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: GetProfileToken.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/RefreshToken.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Authorization/RefreshToken.swift
@@ -16,10 +16,10 @@ extension Rocket.Authorization {
 
             public var body: TokenRefreshRequest
 
-            public init(body: TokenRefreshRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: TokenRefreshRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: RefreshToken.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: RefreshToken.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Registration/Register.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Registration/Register.swift
@@ -25,10 +25,10 @@ email address. This confirmation is done via the /verify-email endpoint.
 
             public var body: RegistrationRequest
 
-            public init(body: RegistrationRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: RegistrationRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: Register.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: Register.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Support/ForgotPassword.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Support/ForgotPassword.swift
@@ -23,10 +23,10 @@ endpoint here, along with the password reset token provided in the original link
 
             public var body: PasswordResetEmailRequest
 
-            public init(body: PasswordResetEmailRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: PasswordResetEmailRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: ForgotPassword.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: ForgotPassword.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/Rocket/generated/Swift/Sources/Requests/Support/ResetPassword.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Requests/Support/ResetPassword.swift
@@ -24,10 +24,10 @@ header as a bearer token.
 
             public var body: PasswordResetRequest
 
-            public init(body: PasswordResetRequest, jsonEncoder: JSONEncoder = Rocket.defaultJSONEncoder) {
+            public init(body: PasswordResetRequest, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: ResetPassword.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: ResetPassword.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Specs/TBX/generated/Swift/Sources/API.swift
+++ b/Specs/TBX/generated/Swift/Sources/API.swift
@@ -16,14 +16,6 @@ public struct TBX {
     /// Used to encode Dates when uses as string params
     public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
 
-    /// Default JSONEncoder used to enconde each API request
-    public static var defaultJSONEncoder: JSONEncoder {
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .formatted(TBX.dateEncodingFormatter)
-
-        return jsonEncoder
-    }
-
     public static let version = "2.4.1"
 
     public enum AuthorizationService {}

--- a/Specs/TBX/generated/Swift/Sources/APIClient.swift
+++ b/Specs/TBX/generated/Swift/Sources/APIClient.swift
@@ -24,6 +24,7 @@ public class APIClient {
     public var defaultHeaders: [String: String]
 
     public var jsonDecoder = JSONDecoder()
+    public var jsonEncoder = JSONEncoder()
 
     public var decodingQueue = DispatchQueue(label: "apiClient", qos: .utility, attributes: .concurrent)
 
@@ -33,6 +34,7 @@ public class APIClient {
         self.behaviours = behaviours
         self.defaultHeaders = defaultHeaders
         jsonDecoder.dateDecodingStrategy = .custom(dateDecoder)
+        jsonEncoder.dateEncodingStrategy = .formatted(TBX.dateEncodingFormatter)
     }
 
     /// Makes a network request
@@ -51,7 +53,7 @@ public class APIClient {
         // create the url request from the request
         var urlRequest: URLRequest
         do {
-            urlRequest = try request.createURLRequest(baseURL: baseURL)
+            urlRequest = try request.createURLRequest(baseURL: baseURL, encoder: jsonEncoder)
         } catch {
             let error = APIClientError.requestEncodingError(error)
             requestBehaviour.onFailure(error: error)
@@ -213,7 +215,7 @@ extension APIRequest {
 extension APIRequest {
 
     /// pass in an optional baseURL, otherwise URLRequest.url will be relative
-    public func createURLRequest(baseURL: String = "") throws -> URLRequest {
+    public func createURLRequest(baseURL: String = "", encoder: RequestEncoder = JSONEncoder()) throws -> URLRequest {
         let url = URL(string: "\(baseURL)\(path)")!
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = service.method
@@ -240,7 +242,7 @@ extension APIRequest {
             urlRequest = try URLEncoding.httpBody.encode(urlRequest, with: formParams)
         }
         if let encodeBody = encodeBody {
-            urlRequest.httpBody = try encodeBody()
+            urlRequest.httpBody = try encodeBody(encoder)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
         return urlRequest

--- a/Specs/TBX/generated/Swift/Sources/APIRequest.swift
+++ b/Specs/TBX/generated/Swift/Sources/APIRequest.swift
@@ -10,7 +10,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
     public let service: APIService<ResponseType>
     public private(set) var queryParameters: [String: Any]
     public private(set) var formParameters: [String: Any]
-    public let encodeBody: (() throws -> Data)?
+    public let encodeBody: ((RequestEncoder) throws -> Data)?
     private(set) var headerParameters: [String: String]
     public var customHeaders: [String: String] = [:]
 
@@ -26,7 +26,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
                 queryParameters: [String: Any] = [:], 
                 formParameters: [String: Any] = [:],
                 headers: [String: String] = [:], 
-                encodeBody: (() throws -> Data)? = nil) {
+                encodeBody: ((RequestEncoder) throws -> Data)? = nil) {
         self.service = service
         self.queryParameters = queryParameters
         self.formParameters = formParameters
@@ -51,7 +51,7 @@ extension APIRequest: CustomDebugStringConvertible {
     public var debugDescription: String {
         var string = description
         if let encodeBody = encodeBody,
-            let data = try? encodeBody(),
+            let data = try? encodeBody(JSONEncoder()),
             let bodyString = String(data: data, encoding: .utf8) {
             string += "\nbody: \(bodyString)"
         }

--- a/Specs/TBX/generated/Swift/Sources/Coding.swift
+++ b/Specs/TBX/generated/Swift/Sources/Coding.swift
@@ -18,6 +18,13 @@ public protocol ResponseDecoder {
 
 extension JSONDecoder: ResponseDecoder {}
 
+public protocol RequestEncoder {
+
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+extension JSONEncoder: RequestEncoder {}
+
 extension APIModel {
     func encode() -> [String: Any] {
         guard

--- a/Specs/TFL/generated/Swift/Sources/API.swift
+++ b/Specs/TFL/generated/Swift/Sources/API.swift
@@ -16,14 +16,6 @@ public struct TFL {
     /// Used to encode Dates when uses as string params
     public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
 
-    /// Default JSONEncoder used to enconde each API request
-    public static var defaultJSONEncoder: JSONEncoder {
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .formatted(TFL.dateEncodingFormatter)
-
-        return jsonEncoder
-    }
-
     public static let version = "v1"
 
     public enum AccidentStats {}

--- a/Specs/TFL/generated/Swift/Sources/APIRequest.swift
+++ b/Specs/TFL/generated/Swift/Sources/APIRequest.swift
@@ -10,7 +10,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
     public let service: APIService<ResponseType>
     public private(set) var queryParameters: [String: Any]
     public private(set) var formParameters: [String: Any]
-    public let encodeBody: (() throws -> Data)?
+    public let encodeBody: ((RequestEncoder) throws -> Data)?
     private(set) var headerParameters: [String: String]
     public var customHeaders: [String: String] = [:]
 
@@ -26,7 +26,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
                 queryParameters: [String: Any] = [:], 
                 formParameters: [String: Any] = [:],
                 headers: [String: String] = [:], 
-                encodeBody: (() throws -> Data)? = nil) {
+                encodeBody: ((RequestEncoder) throws -> Data)? = nil) {
         self.service = service
         self.queryParameters = queryParameters
         self.formParameters = formParameters
@@ -51,7 +51,7 @@ extension APIRequest: CustomDebugStringConvertible {
     public var debugDescription: String {
         var string = description
         if let encodeBody = encodeBody,
-            let data = try? encodeBody(),
+            let data = try? encodeBody(JSONEncoder()),
             let bodyString = String(data: data, encoding: .utf8) {
             string += "\nbody: \(bodyString)"
         }

--- a/Specs/TFL/generated/Swift/Sources/Coding.swift
+++ b/Specs/TFL/generated/Swift/Sources/Coding.swift
@@ -18,6 +18,13 @@ public protocol ResponseDecoder {
 
 extension JSONDecoder: ResponseDecoder {}
 
+public protocol RequestEncoder {
+
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+extension JSONEncoder: RequestEncoder {}
+
 extension APIModel {
     func encode() -> [String: Any] {
         guard

--- a/Specs/TestSpec/generated/Swift/Sources/API.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/API.swift
@@ -16,13 +16,5 @@ public struct TestSpec {
     /// Used to encode Dates when uses as string params
     public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
 
-    /// Default JSONEncoder used to enconde each API request
-    public static var defaultJSONEncoder: JSONEncoder {
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .formatted(TestSpec.dateEncodingFormatter)
-
-        return jsonEncoder
-    }
-
     public static let version = "1.0"
 }

--- a/Specs/TestSpec/generated/Swift/Sources/APIClient.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/APIClient.swift
@@ -24,6 +24,7 @@ public class APIClient {
     public var defaultHeaders: [String: String]
 
     public var jsonDecoder = JSONDecoder()
+    public var jsonEncoder = JSONEncoder()
 
     public var decodingQueue = DispatchQueue(label: "apiClient", qos: .utility, attributes: .concurrent)
 
@@ -33,6 +34,7 @@ public class APIClient {
         self.behaviours = behaviours
         self.defaultHeaders = defaultHeaders
         jsonDecoder.dateDecodingStrategy = .custom(dateDecoder)
+        jsonEncoder.dateEncodingStrategy = .formatted(TestSpec.dateEncodingFormatter)
     }
 
     /// Makes a network request
@@ -51,7 +53,7 @@ public class APIClient {
         // create the url request from the request
         var urlRequest: URLRequest
         do {
-            urlRequest = try request.createURLRequest(baseURL: baseURL)
+            urlRequest = try request.createURLRequest(baseURL: baseURL, encoder: jsonEncoder)
         } catch {
             let error = APIClientError.requestEncodingError(error)
             requestBehaviour.onFailure(error: error)
@@ -213,7 +215,7 @@ extension APIRequest {
 extension APIRequest {
 
     /// pass in an optional baseURL, otherwise URLRequest.url will be relative
-    public func createURLRequest(baseURL: String = "") throws -> URLRequest {
+    public func createURLRequest(baseURL: String = "", encoder: RequestEncoder = JSONEncoder()) throws -> URLRequest {
         let url = URL(string: "\(baseURL)\(path)")!
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = service.method
@@ -240,7 +242,7 @@ extension APIRequest {
             urlRequest = try URLEncoding.httpBody.encode(urlRequest, with: formParams)
         }
         if let encodeBody = encodeBody {
-            urlRequest.httpBody = try encodeBody()
+            urlRequest.httpBody = try encodeBody(encoder)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
         return urlRequest

--- a/Specs/TestSpec/generated/Swift/Sources/APIRequest.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/APIRequest.swift
@@ -10,7 +10,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
     public let service: APIService<ResponseType>
     public private(set) var queryParameters: [String: Any]
     public private(set) var formParameters: [String: Any]
-    public let encodeBody: (() throws -> Data)?
+    public let encodeBody: ((RequestEncoder) throws -> Data)?
     private(set) var headerParameters: [String: String]
     public var customHeaders: [String: String] = [:]
 
@@ -26,7 +26,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
                 queryParameters: [String: Any] = [:], 
                 formParameters: [String: Any] = [:],
                 headers: [String: String] = [:], 
-                encodeBody: (() throws -> Data)? = nil) {
+                encodeBody: ((RequestEncoder) throws -> Data)? = nil) {
         self.service = service
         self.queryParameters = queryParameters
         self.formParameters = formParameters
@@ -51,7 +51,7 @@ extension APIRequest: CustomDebugStringConvertible {
     public var debugDescription: String {
         var string = description
         if let encodeBody = encodeBody,
-            let data = try? encodeBody(),
+            let data = try? encodeBody(JSONEncoder()),
             let bodyString = String(data: data, encoding: .utf8) {
             string += "\nbody: \(bodyString)"
         }

--- a/Specs/TestSpec/generated/Swift/Sources/Coding.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Coding.swift
@@ -18,6 +18,13 @@ public protocol ResponseDecoder {
 
 extension JSONDecoder: ResponseDecoder {}
 
+public protocol RequestEncoder {
+
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+extension JSONEncoder: RequestEncoder {}
+
 extension APIModel {
     func encode() -> [String: Any] {
         guard

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/PostAllParams.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/PostAllParams.swift
@@ -80,11 +80,11 @@ extension TestSpec {
 
             public var body: Body?
 
-            public init(body: Body?, options: Options, jsonEncoder: JSONEncoder = TestSpec.defaultJSONEncoder) {
+            public init(body: Body?, options: Options, encoder: RequestEncoder? = nil) {
                 self.body = body
                 self.options = options
-                super.init(service: PostAllParams.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: PostAllParams.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
 

--- a/Specs/TestSpec/generated/Swift/Sources/Requests/PostInlinebody.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Requests/PostInlinebody.swift
@@ -54,10 +54,10 @@ extension TestSpec {
 
             public var body: Body
 
-            public init(body: Body, jsonEncoder: JSONEncoder = TestSpec.defaultJSONEncoder) {
+            public init(body: Body, encoder: RequestEncoder? = nil) {
                 self.body = body
-                super.init(service: PostInlinebody.service) {
-                    return try jsonEncoder.encode(body)
+                super.init(service: PostInlinebody.service) { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode(body)
                 }
             }
         }

--- a/Templates/Swift/Sources/API.swift
+++ b/Templates/Swift/Sources/API.swift
@@ -16,14 +16,6 @@ public struct {{ options.name }} {
     /// Used to encode Dates when uses as string params
     public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
     
-    /// Default JSONEncoder used to enconde each API request
-    public static var defaultJSONEncoder: JSONEncoder {
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .formatted({{ options.name }}.dateEncodingFormatter)
-        
-        return jsonEncoder
-    }
-    
     {% if info.version %}
     public static let version = "{{ info.version }}"
     {% endif %}

--- a/Templates/Swift/Sources/APIClient.swift
+++ b/Templates/Swift/Sources/APIClient.swift
@@ -21,6 +21,7 @@ public class APIClient {
     public var defaultHeaders: [String: String]
 
     public var jsonDecoder = JSONDecoder()
+    public var jsonEncoder = JSONEncoder()
 
     public var decodingQueue = DispatchQueue(label: "apiClient", qos: .utility, attributes: .concurrent)
 
@@ -30,6 +31,7 @@ public class APIClient {
         self.behaviours = behaviours
         self.defaultHeaders = defaultHeaders
         jsonDecoder.dateDecodingStrategy = .custom(dateDecoder)
+        jsonEncoder.dateEncodingStrategy = .formatted({{ options.name }}.dateEncodingFormatter)
     }
 
     /// Makes a network request
@@ -48,7 +50,7 @@ public class APIClient {
         // create the url request from the request
         var urlRequest: URLRequest
         do {
-            urlRequest = try request.createURLRequest(baseURL: baseURL)
+            urlRequest = try request.createURLRequest(baseURL: baseURL, encoder: jsonEncoder)
         } catch {
             let error = APIClientError.requestEncodingError(error)
             requestBehaviour.onFailure(error: error)
@@ -210,7 +212,7 @@ extension APIRequest {
 extension APIRequest {
 
     /// pass in an optional baseURL, otherwise URLRequest.url will be relative
-    public func createURLRequest(baseURL: String = "") throws -> URLRequest {
+    public func createURLRequest(baseURL: String = "", encoder: RequestEncoder = JSONEncoder()) throws -> URLRequest {
         let url = URL(string: "\(baseURL)\(path)")!
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = service.method
@@ -237,7 +239,7 @@ extension APIRequest {
             urlRequest = try URLEncoding.httpBody.encode(urlRequest, with: formParams)
         }
         if let encodeBody = encodeBody {
-            urlRequest.httpBody = try encodeBody()
+            urlRequest.httpBody = try encodeBody(encoder)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
         return urlRequest

--- a/Templates/Swift/Sources/APIRequest.swift
+++ b/Templates/Swift/Sources/APIRequest.swift
@@ -7,7 +7,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
     public let service: APIService<ResponseType>
     public private(set) var queryParameters: [String: Any]
     public private(set) var formParameters: [String: Any]
-    public let encodeBody: (() throws -> Data)?
+    public let encodeBody: ((RequestEncoder) throws -> Data)?
     private(set) var headerParameters: [String: String]
     public var customHeaders: [String: String] = [:]
 
@@ -23,7 +23,7 @@ public class APIRequest<ResponseType: APIResponseValue> {
                 queryParameters: [String: Any] = [:], 
                 formParameters: [String: Any] = [:],
                 headers: [String: String] = [:], 
-                encodeBody: (() throws -> Data)? = nil) {
+                encodeBody: ((RequestEncoder) throws -> Data)? = nil) {
         self.service = service
         self.queryParameters = queryParameters
         self.formParameters = formParameters
@@ -48,7 +48,7 @@ extension APIRequest: CustomDebugStringConvertible {
     public var debugDescription: String {
         var string = description
         if let encodeBody = encodeBody,
-            let data = try? encodeBody(),
+            let data = try? encodeBody(JSONEncoder()),
             let bodyString = String(data: data, encoding: .utf8) {
             string += "\nbody: \(bodyString)"
         }

--- a/Templates/Swift/Sources/Coding.swift
+++ b/Templates/Swift/Sources/Coding.swift
@@ -17,6 +17,13 @@ public protocol ResponseDecoder {
 
 extension JSONDecoder: ResponseDecoder {}
 
+public protocol RequestEncoder {
+
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+extension JSONEncoder: RequestEncoder {}
+
 extension {{ options.modelProtocol }} {
     func encode() -> [String: Any] {
         guard

--- a/Templates/Swift/Sources/Request.swift
+++ b/Templates/Swift/Sources/Request.swift
@@ -62,15 +62,15 @@ extension {{ options.name }}{% if tag %}.{{ options.tagPrefix }}{{ tag|upperCame
             public var {{ body.name}}: {{body.optionalType}}
             {% endif %}
 
-            public init({% if body %}{{ body.name}}: {{ body.optionalType }}{% if nonBodyParams %}, {% endif %}{% endif %}{% if nonBodyParams %}options: Options{% endif %}{% if body %}, jsonEncoder: JSONEncoder = {{ options.name }}.defaultJSONEncoder{% endif %}) {
+            public init({% if body %}{{ body.name}}: {{ body.optionalType }}{% if nonBodyParams %}, {% endif %}{% endif %}{% if nonBodyParams %}options: Options{% endif %}{% if body %}, encoder: RequestEncoder? = nil{% endif %}) {
                 {% if body %}
                 self.{{ body.name}} = {{ body.name}}
                 {% endif %}
                 {% if nonBodyParams %}
                 self.options = options
                 {% endif %}
-                super.init(service: {{ type }}.service){% if body %} {
-                    return try jsonEncoder.encode({% if body.isAnyType %}AnyCodable({{ body.name }}).value{% else %}{{ body.name }}{% endif %})
+                super.init(service: {{ type }}.service){% if body %} { defaultEncoder in
+                    return try (encoder ?? defaultEncoder).encode({% if body.isAnyType %}AnyCodable({{ body.name }}).value{% else %}{{ body.name }}{% endif %})
                 }{% endif %}
             }
             {% if nonBodyParams %}


### PR DESCRIPTION
This is a followup to #172
It adds a `jsonEncoder` to `APIClient` that can be customized. It also hides it behind a `RequestEncoder` protocol, so other encoders can be used