### PR TITLE
add public init for ObjectSchema

### DIFF
--- a/Sources/Swagger/Schema/ObjectSchema.swift
+++ b/Sources/Swagger/Schema/ObjectSchema.swift
@@ -9,6 +9,24 @@ public struct ObjectSchema {
     public let additionalProperties: Schema?
     public let abstract: Bool
     public let discriminator: Discriminator?
+
+    public init(requiredProperties: [Property],
+                optionalProperties: [Property],
+                properties: [Property],
+                minProperties: Int? = nil,
+                maxProperties: Int? = nil,
+                additionalProperties: Schema? = nil,
+                abstract: Bool = false,
+                discriminator: Discriminator? = nil) {
+        self.requiredProperties = requiredProperties
+        self.optionalProperties = optionalProperties
+        self.properties = properties
+        self.minProperties = minProperties
+        self.maxProperties = maxProperties
+        self.additionalProperties = additionalProperties
+        self.abstract = abstract
+        self.discriminator = discriminator
+    }
 }
 
 public struct Property {


### PR DESCRIPTION
While using Swagger I faced a problem with Swift 5.
In my framework I tried to write custom init for ObjectSchema, but the compiler was strongly against it:  "let property ‘anyProperty’ may not be initialized directly." 
And there was no ObjectSchema default public init because memberwise init is internal. 
Of course, it is a bug because with Swift 4 described scheme compiles correctly.
But still it is important to provide public default init for public structs.
 