### PR TITLE
Use first group schema type when there is only one group schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed inline allOf group generation
+- Fixed property generation when there is only one group schema;  the first group schema type will be used as the type #217
 
 ## 4.3.1
 

--- a/Sources/SwagGenKit/SwaggerExtensions.swift
+++ b/Sources/SwagGenKit/SwaggerExtensions.swift
@@ -154,12 +154,7 @@ extension Schema {
                 break
             }
         case let .group(group):
-            switch group.type {
-            case .any, .one:
-                if group.discriminator != nil {
-                    return self
-                }
-            case .all:
+            if group.discriminator != nil {
                 return self
             }
         default: break

--- a/Sources/SwagGenKit/SwiftFormatter.swift
+++ b/Sources/SwagGenKit/SwiftFormatter.swift
@@ -151,7 +151,12 @@ public class SwiftFormatter: CodeFormatter {
             }
         case let .reference(reference):
             return getSchemaTypeName(reference.component)
-        case .group:
+        case let .group(groupSchema):
+            if groupSchema.schemas.count == 1, let singleGroupSchema = groupSchema.schemas.first {
+                //flatten group schemas with only one schema
+                return getSchemaType(name: name, schema: singleGroupSchema)
+            }
+
             return escapeType(name.upperCamelCased())
         case .any:
             return "Any"

--- a/Specs/TestSpec/generated/Swift/Sources/Models/Zoo.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/Zoo.swift
@@ -7,31 +7,17 @@ import Foundation
 
 public class Zoo: APIModel {
 
-    public var inlineAnimal: InlineAnimal?
+    public var allOfDog: Dog?
+
+    public var anyOfDog: Dog?
+
+    public var inlineAnimal: Animal?
 
     public var inlineAnimals: [InlineAnimals]?
 
+    public var oneOfDog: Dog?
+
     public var schemaAnimals: [SingleAnimal]?
-
-    public class InlineAnimal: Animal {
-
-        public override init(animal: String? = nil) {
-            super.init(animal: animal)
-        }
-
-        public required init(from decoder: Decoder) throws {
-            try super.init(from: decoder)
-        }
-
-        public override func encode(to encoder: Encoder) throws {
-            try super.encode(to: encoder)
-        }
-
-        override public func isEqual(to object: Any?) -> Bool {
-          guard object is InlineAnimal else { return false }
-          return super.isEqual(to: object)
-        }
-    }
 
     public enum InlineAnimals: Codable, Equatable {
         case cat(Cat)
@@ -61,32 +47,44 @@ public class Zoo: APIModel {
         }
     }
 
-    public init(inlineAnimal: InlineAnimal? = nil, inlineAnimals: [InlineAnimals]? = nil, schemaAnimals: [SingleAnimal]? = nil) {
+    public init(allOfDog: Dog? = nil, anyOfDog: Dog? = nil, inlineAnimal: Animal? = nil, inlineAnimals: [InlineAnimals]? = nil, oneOfDog: Dog? = nil, schemaAnimals: [SingleAnimal]? = nil) {
+        self.allOfDog = allOfDog
+        self.anyOfDog = anyOfDog
         self.inlineAnimal = inlineAnimal
         self.inlineAnimals = inlineAnimals
+        self.oneOfDog = oneOfDog
         self.schemaAnimals = schemaAnimals
     }
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: StringCodingKey.self)
 
+        allOfDog = try container.decodeIfPresent("allOfDog")
+        anyOfDog = try container.decodeIfPresent("anyOfDog")
         inlineAnimal = try container.decodeIfPresent("inlineAnimal")
         inlineAnimals = try container.decodeArrayIfPresent("inlineAnimals")
+        oneOfDog = try container.decodeIfPresent("oneOfDog")
         schemaAnimals = try container.decodeArrayIfPresent("schemaAnimals")
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: StringCodingKey.self)
 
+        try container.encodeIfPresent(allOfDog, forKey: "allOfDog")
+        try container.encodeIfPresent(anyOfDog, forKey: "anyOfDog")
         try container.encodeIfPresent(inlineAnimal, forKey: "inlineAnimal")
         try container.encodeIfPresent(inlineAnimals, forKey: "inlineAnimals")
+        try container.encodeIfPresent(oneOfDog, forKey: "oneOfDog")
         try container.encodeIfPresent(schemaAnimals, forKey: "schemaAnimals")
     }
 
     public func isEqual(to object: Any?) -> Bool {
       guard let object = object as? Zoo else { return false }
+      guard self.allOfDog == object.allOfDog else { return false }
+      guard self.anyOfDog == object.anyOfDog else { return false }
       guard self.inlineAnimal == object.inlineAnimal else { return false }
       guard self.inlineAnimals == object.inlineAnimals else { return false }
+      guard self.oneOfDog == object.oneOfDog else { return false }
       guard self.schemaAnimals == object.schemaAnimals else { return false }
       return true
     }

--- a/Specs/TestSpec/spec.yml
+++ b/Specs/TestSpec/spec.yml
@@ -313,6 +313,15 @@ components:
         inlineAnimal:
             allOf:
                 - $ref: '#/components/schemas/Animal'
+        oneOfDog:
+            oneOf:
+                - $ref: '#/components/schemas/Dog'
+        anyOfDog:
+            anyOf:
+                - $ref: '#/components/schemas/Dog'
+        allOfDog:
+            allOf:
+                - $ref: '#/components/schemas/Dog'
     SingleAnimal:
       oneOf:
         - $ref: "#/components/schemas/Cat"


### PR DESCRIPTION
This avoids hitting the fallback to using the property name which without further intervention results in missing types when compiling generated code.

```json
...

"ExampleModel": {
        "type": "object",
        "additionalProperties": false,
        "properties": {
          "exampleProperty": {
            "oneOf": [
              {
                "$ref": "#/components/schemas/ExampleType"
              }
            ]
          }
        }
}
...
```

*Before*

```swift
public var exampleProperty: ExampleProperty
```

*After*

```swift
public var exampleProperty: ExampleType
```

This change still would result in compilation errors for generated code where there was more than one possible schema for a group schema.  Is there a proposed or correct way of handling this?

From what I can tell right now this will just generate the property type using a camel cased property name which seems a bit fragile - I am assuming the intention is this type be implemented manually but that seems error prone as there is the possibility of type collisions.

