### PR TITLE
Enforce 24 hour formatting during date encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed inline allOf group generation
 - Fixed property generation when there is only one group schema;  the first group schema type will be used as the type #217
 - Added `anyType` option that allows to override `Any` in models
+- Fixed date encoding formatter to conform to RFC3339
 
 ## 4.3.1
 

--- a/Specs/Petstore/generated/Swift/Sources/API.swift
+++ b/Specs/Petstore/generated/Swift/Sources/API.swift
@@ -14,7 +14,9 @@ public struct Petstore {
     public static var safeArrayDecoding = false
 
     /// Used to encode Dates when uses as string params
-    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                                                            locale: Locale(identifier: "en_US_POSIX"),
+                                                            calendar: Calendar(identifier: .gregorian))
 
     public static let version = "1.0.0"
 

--- a/Specs/Petstore/generated/Swift/Sources/Coding.swift
+++ b/Specs/Petstore/generated/Swift/Sources/Coding.swift
@@ -193,7 +193,7 @@ extension KeyedEncodingContainer {
 
 extension DateFormatter {
 
-    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil) {
+    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil, calendar: Calendar? = nil) {
         self.init()
         dateFormat = formatString
         if let locale = locale {
@@ -201,6 +201,9 @@ extension DateFormatter {
         }
         if let timeZone = timeZone {
             self.timeZone = timeZone
+        }
+        if let calendar = calendar {
+            self.calendar = calendar
         }
     }
 
@@ -219,11 +222,13 @@ let dateDecoder: (Decoder) throws -> Date = { decoder in
         formatterWithMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         formatterWithMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         let formatterWithoutMilliseconds = DateFormatter()
         formatterWithoutMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         formatterWithoutMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithoutMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithoutMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         guard let date = formatterWithMilliseconds.date(from: string) ??
             formatterWithoutMilliseconds.date(from: string) else {

--- a/Specs/PetstoreTest/generated/Swift/Sources/API.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/API.swift
@@ -15,7 +15,9 @@ public struct PetstoreTest {
     public static var safeArrayDecoding = false
 
     /// Used to encode Dates when uses as string params
-    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                                                            locale: Locale(identifier: "en_US_POSIX"),
+                                                            calendar: Calendar(identifier: .gregorian))
 
     public static let version = "1.0.0"
 

--- a/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Coding.swift
@@ -193,7 +193,7 @@ extension KeyedEncodingContainer {
 
 extension DateFormatter {
 
-    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil) {
+    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil, calendar: Calendar? = nil) {
         self.init()
         dateFormat = formatString
         if let locale = locale {
@@ -201,6 +201,9 @@ extension DateFormatter {
         }
         if let timeZone = timeZone {
             self.timeZone = timeZone
+        }
+        if let calendar = calendar {
+            self.calendar = calendar
         }
     }
 
@@ -219,11 +222,13 @@ let dateDecoder: (Decoder) throws -> Date = { decoder in
         formatterWithMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         formatterWithMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         let formatterWithoutMilliseconds = DateFormatter()
         formatterWithoutMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         formatterWithoutMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithoutMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithoutMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         guard let date = formatterWithMilliseconds.date(from: string) ??
             formatterWithoutMilliseconds.date(from: string) else {

--- a/Specs/Rocket/generated/Swift/Sources/API.swift
+++ b/Specs/Rocket/generated/Swift/Sources/API.swift
@@ -19,7 +19,9 @@ public struct Rocket {
     public static var safeArrayDecoding = false
 
     /// Used to encode Dates when uses as string params
-    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                                                            locale: Locale(identifier: "en_US_POSIX"),
+                                                            calendar: Calendar(identifier: .gregorian))
 
     public static let version = "1.0.0"
 

--- a/Specs/Rocket/generated/Swift/Sources/Coding.swift
+++ b/Specs/Rocket/generated/Swift/Sources/Coding.swift
@@ -193,7 +193,7 @@ extension KeyedEncodingContainer {
 
 extension DateFormatter {
 
-    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil) {
+    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil, calendar: Calendar? = nil) {
         self.init()
         dateFormat = formatString
         if let locale = locale {
@@ -201,6 +201,9 @@ extension DateFormatter {
         }
         if let timeZone = timeZone {
             self.timeZone = timeZone
+        }
+        if let calendar = calendar {
+            self.calendar = calendar
         }
     }
 
@@ -219,11 +222,13 @@ let dateDecoder: (Decoder) throws -> Date = { decoder in
         formatterWithMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         formatterWithMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         let formatterWithoutMilliseconds = DateFormatter()
         formatterWithoutMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         formatterWithoutMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithoutMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithoutMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         guard let date = formatterWithMilliseconds.date(from: string) ??
             formatterWithoutMilliseconds.date(from: string) else {

--- a/Specs/TBX/generated/Swift/Sources/API.swift
+++ b/Specs/TBX/generated/Swift/Sources/API.swift
@@ -14,7 +14,9 @@ public struct TBX {
     public static var safeArrayDecoding = false
 
     /// Used to encode Dates when uses as string params
-    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                                                            locale: Locale(identifier: "en_US_POSIX"),
+                                                            calendar: Calendar(identifier: .gregorian))
 
     public static let version = "2.4.1"
 

--- a/Specs/TBX/generated/Swift/Sources/Coding.swift
+++ b/Specs/TBX/generated/Swift/Sources/Coding.swift
@@ -193,7 +193,7 @@ extension KeyedEncodingContainer {
 
 extension DateFormatter {
 
-    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil) {
+    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil, calendar: Calendar? = nil) {
         self.init()
         dateFormat = formatString
         if let locale = locale {
@@ -201,6 +201,9 @@ extension DateFormatter {
         }
         if let timeZone = timeZone {
             self.timeZone = timeZone
+        }
+        if let calendar = calendar {
+            self.calendar = calendar
         }
     }
 
@@ -219,11 +222,13 @@ let dateDecoder: (Decoder) throws -> Date = { decoder in
         formatterWithMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         formatterWithMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         let formatterWithoutMilliseconds = DateFormatter()
         formatterWithoutMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         formatterWithoutMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithoutMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithoutMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         guard let date = formatterWithMilliseconds.date(from: string) ??
             formatterWithoutMilliseconds.date(from: string) else {

--- a/Specs/TFL/generated/Swift/Sources/API.swift
+++ b/Specs/TFL/generated/Swift/Sources/API.swift
@@ -14,7 +14,9 @@ public struct TFL {
     public static var safeArrayDecoding = false
 
     /// Used to encode Dates when uses as string params
-    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                                                            locale: Locale(identifier: "en_US_POSIX"),
+                                                            calendar: Calendar(identifier: .gregorian))
 
     public static let version = "v1"
 

--- a/Specs/TFL/generated/Swift/Sources/Coding.swift
+++ b/Specs/TFL/generated/Swift/Sources/Coding.swift
@@ -193,7 +193,7 @@ extension KeyedEncodingContainer {
 
 extension DateFormatter {
 
-    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil) {
+    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil, calendar: Calendar? = nil) {
         self.init()
         dateFormat = formatString
         if let locale = locale {
@@ -201,6 +201,9 @@ extension DateFormatter {
         }
         if let timeZone = timeZone {
             self.timeZone = timeZone
+        }
+        if let calendar = calendar {
+            self.calendar = calendar
         }
     }
 
@@ -219,11 +222,13 @@ let dateDecoder: (Decoder) throws -> Date = { decoder in
         formatterWithMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         formatterWithMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         let formatterWithoutMilliseconds = DateFormatter()
         formatterWithoutMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         formatterWithoutMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithoutMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithoutMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         guard let date = formatterWithMilliseconds.date(from: string) ??
             formatterWithoutMilliseconds.date(from: string) else {

--- a/Specs/TestSpec/generated/Swift/Sources/API.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/API.swift
@@ -14,7 +14,9 @@ public struct TestSpec {
     public static var safeArrayDecoding = false
 
     /// Used to encode Dates when uses as string params
-    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                                                            locale: Locale(identifier: "en_US_POSIX"),
+                                                            calendar: Calendar(identifier: .gregorian))
 
     public static let version = "1.0"
 }

--- a/Specs/TestSpec/generated/Swift/Sources/Coding.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Coding.swift
@@ -193,7 +193,7 @@ extension KeyedEncodingContainer {
 
 extension DateFormatter {
 
-    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil) {
+    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil, calendar: Calendar? = nil) {
         self.init()
         dateFormat = formatString
         if let locale = locale {
@@ -201,6 +201,9 @@ extension DateFormatter {
         }
         if let timeZone = timeZone {
             self.timeZone = timeZone
+        }
+        if let calendar = calendar {
+            self.calendar = calendar
         }
     }
 
@@ -219,11 +222,13 @@ let dateDecoder: (Decoder) throws -> Date = { decoder in
         formatterWithMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         formatterWithMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         let formatterWithoutMilliseconds = DateFormatter()
         formatterWithoutMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         formatterWithoutMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithoutMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithoutMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         guard let date = formatterWithMilliseconds.date(from: string) ??
             formatterWithoutMilliseconds.date(from: string) else {

--- a/Templates/Swift/Sources/API.swift
+++ b/Templates/Swift/Sources/API.swift
@@ -14,7 +14,7 @@ public struct {{ options.name }} {
     public static var safeArrayDecoding = {% if options.safeArrayDecoding %}true{% else %}false{% endif %}
 
     /// Used to encode Dates when uses as string params
-    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ", locale: Locale(identifier: "en_US_POSIX"))
     
     {% if info.version %}
     public static let version = "{{ info.version }}"

--- a/Templates/Swift/Sources/API.swift
+++ b/Templates/Swift/Sources/API.swift
@@ -14,7 +14,9 @@ public struct {{ options.name }} {
     public static var safeArrayDecoding = {% if options.safeArrayDecoding %}true{% else %}false{% endif %}
 
     /// Used to encode Dates when uses as string params
-    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ", locale: Locale(identifier: "en_US_POSIX"))
+    public static var dateEncodingFormatter = DateFormatter(formatString: "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+                                                            locale: Locale(identifier: "en_US_POSIX"),
+                                                            calendar: Calendar(identifier: .gregorian))
     
     {% if info.version %}
     public static let version = "{{ info.version }}"

--- a/Templates/Swift/Sources/Coding.swift
+++ b/Templates/Swift/Sources/Coding.swift
@@ -192,7 +192,7 @@ extension KeyedEncodingContainer {
 
 extension DateFormatter {
 
-    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil) {
+    convenience init(formatString: String, locale: Locale? = nil, timeZone: TimeZone? = nil, calendar: Calendar? = nil) {
         self.init()
         dateFormat = formatString
         if let locale = locale {
@@ -200,6 +200,9 @@ extension DateFormatter {
         }
         if let timeZone = timeZone {
             self.timeZone = timeZone
+        }
+        if let calendar = calendar {
+            self.calendar = calendar
         }
     }
 
@@ -218,11 +221,13 @@ let dateDecoder: (Decoder) throws -> Date = { decoder in
         formatterWithMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         formatterWithMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         let formatterWithoutMilliseconds = DateFormatter()
         formatterWithoutMilliseconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         formatterWithoutMilliseconds.locale = Locale(identifier: "en_US_POSIX")
         formatterWithoutMilliseconds.timeZone = TimeZone(identifier: "UTC")
+        formatterWithoutMilliseconds.calendar = Calendar(identifier: .gregorian)
 
         guard let date = formatterWithMilliseconds.date(from: string) ??
             formatterWithoutMilliseconds.date(from: string) else {


### PR DESCRIPTION
Hi @yonaskolb,

thanks a lot for bringing this project to life and maintaining it 🙌 It's a breeze to use!

I recently encountered an issue where the backend failed to parse timestamps generated using our generated code. For example:
```
2020-03-24T9:56:03Z
```
The problematic part here is the hour component of the timestamp: `9`
According to the format specified by the generated code `HH` (as well as the format expected by our backend), the hour component should be padded, i.e two digits: `09`

After a bit of investigation, it turned out that the affected users in question had set their phones to use 12-hour time instead of 24-hour time. This has two consequences:
1) Between 1 and 9 am/pm, the hour component of the timestamp has a single digit, going against the expected format
2) Generally, even if the timestamp has the expected length (between 10 and 12 am/pm), the hour component doesn't differentiate between e.g. 11am and 11pm (whereas the former should appear as 11 and the latter should appear as 23)

It appears that Apple also [officially recommends](https://developer.apple.com/library/archive/qa/qa1480/_index.html)  using the `en_US_POSIX` locale in these situations - as the formatters for decoding in `Coding.swift` already do.

The necessary changes to fix this I added in the first commit, e7e9563.

Additionally, while at it, I noticed the formatters don't have the Gregorian calendar set, although specified according to [RFC3339](https://tools.ietf.org/html/rfc3339), so I took the liberty to also add this in the second commit, bfa0acc. While doing this I noticed `DateDay.dateFormatter` has set the calendar to `current` purposefully, so I didn't touch it but wanted to bring it up here instead.

