### PR TITLE
Add support for running scripts after code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+### Added
+- Added ability perform scripts after the code generation #234  @mackoj
+
 ### Fixed
 - Fixed inline allOf group generation
 - Fixed property generation when there is only one group schema;  the first group schema type will be used as the type #217

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ tagPrefix | prefix for all tags | `String` | null
 tagSuffix | suffix for all tags | `String` | null
 codableResponses | constrains all responses to be `Codable` | `Bool` | false
 anyType | override `Any` with custom type | `String` | `Any`
+postGenerationScript | perform the script after the code generation. If you use `__DESTNATION_PATH__` it will change it to the destination path | `[String]` | `[]`
 
 If writing your own Swift template there are a few types that are generated that you will need to provide typealias's for:
 

--- a/Sources/SwagGen/GenerateCommand.swift
+++ b/Sources/SwagGen/GenerateCommand.swift
@@ -219,6 +219,13 @@ class GenerateCommand: Command {
                     standardOut("Removed \(relativePath)".red)
                 }
             }
+            if let postGenerationScripts = templateConfig.options["postGenerationScript"] as? [String] {
+              for postGenerationScript in postGenerationScripts {
+                let script = postGenerationScript.replacingOccurrences(of: "__DESTINATION_PATH__", with: "\"\(destinationPath)\"")
+                let scriptOutput = try shell(script)
+                standardOut(scriptOutput)
+              }
+            }
             standardOut("Generation complete: \(generationResult)")
         } catch {
             exitWithError("Error generating code: \(error)")

--- a/Sources/SwagGen/Shell.swift
+++ b/Sources/SwagGen/Shell.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public enum ShellError: Error { case pipeOutputFailedToDecode }
+
+@discardableResult public func shell(_ command: String) throws -> String {
+  let task = Process()
+  task.launchPath = "/bin/bash"
+  task.arguments = ["-c", command]
+  return try performShellOperation(task)
+}
+
+@discardableResult public func shell(_ command: String, arguments: [String]) throws -> String {
+  let task = Process()
+  task.launchPath = "/bin/bash"
+  task.arguments = arguments
+  return try performShellOperation(task)
+}
+
+// MARK: - Private
+
+private func performShellOperation(_ task: Process) throws -> String {
+  let pipe = Pipe()
+  task.standardOutput = pipe
+  task.launch()
+
+  let data = pipe.fileHandleForReading.readDataToEndOfFile()
+  guard let output:String = String(data: data, encoding: .utf8) else {
+    throw (ShellError.pipeOutputFailedToDecode)
+  }
+
+  return output
+}

--- a/Templates/Swift/template.yml
+++ b/Templates/Swift/template.yml
@@ -16,6 +16,7 @@ options:
   codableResponses: false # constrains all responses/model to be Codable
   propertyNames: {} # override property names
   anyType: Any # override Any in generated models
+  postGenerationScript: [] # script to execute post generation
   typeAliases:
     ID: UUID
     DateTime: Date


### PR DESCRIPTION
The goal of this PR is to allow to run scripts on generated code after the generation.

You will need to add `postGenerationScript: ["<script call here>", "<another script>"]` in your **template.yml** file in order for it to work.

This is an exemple of what it can do.

```yml
  postGenerationScript: ["swift-format -m format  -r -i __DESTNATION_PATH__"] # script to execute post generation
```

Adding this will reformat the generated code with [swift-format](https://github.com/apple/swift-format).

For the moment it only have one context variable `__DESTNATION_PATH__` that will transform into the final **destinationPath**.

I hope it helps.