### PR TITLE
Docker Support

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -1,0 +1,43 @@
+# swaggen-docker
+
+**Official Docker image** for [SwagGen](https://github.com/yonaskolb/SwagGen)
+
+## Update process
+
+In order to update the docker image just run `./updateDockerImage.sh`
+If Swift or Swaggen has a new version it will create a new docker container accordingly.
+
+This require you to have installed `swift-sh`([Github](https://github.com/mxcl/swift-sh)).
+
+## Available Tags
+
+<!--* `4.3.1-slim`, `latest` ([_Dockerfile_](https://github.com/mackoj/swaggen-docker/blob/4.3.1-slim/Dockerfile))
+* `4.3.0-slim` ([_Dockerfile_](https://github.com/mackoj/swaggen-docker/blob/4.3.0-slim/Dockerfile))
+* `4.2.0-slim` ([_Dockerfile_](https://github.com/mackoj/swaggen-docker/blob/v4.2.0/Dockerfile))
+* `4.2.0` ([_Dockerfile_](https://github.com/mackoj/swaggen-docker/blob/v4.2.0/Dockerfile)) -->
+
+## Usage
+
+```bash
+# Pull this image
+docker pull yonaskolb/swaggen:latest
+
+declare DOCKER_MOUNTED_PATH="/tmp/workdir"
+
+curl https://www.mysite.com/swagger.json -o api.json
+
+# Run swaggen
+#   - This assumes your spec file is in $(pwd)/spec.json
+#   - Generated code will be available in $(pwd)/swaggen-output
+
+docker run                                                              \
+  --rm                                                                  \
+  -v "$(pwd):${DOCKER_MOUNTED_PATH}"                                    \
+  yonaskolb/swaggen:latest                                                 \
+  swaggen generate "${DOCKER_MOUNTED_PATH}/api.json"                    \
+  --language swift                                                      \
+  --template "${DOCKER_MOUNTED_PATH}/Templates/Swift/template.yml"      \
+  --destination "${DOCKER_MOUNTED_PATH}/Generated/Swift"                \
+  --clean all                                                           \
+  --verbose
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+###############################################################################
+# DOCKERFILE FOR swaggen
+###############################################################################
+
+# -----------------------------------------------------------------------------
+# BUILD STAGE
+# -----------------------------------------------------------------------------
+
+FROM swift:latest as builder
+
+RUN apt-get update && apt-get install -y curl
+
+ARG DOCKER_IMAGE_DESCRIPTION
+ARG MAINTAINER
+ARG EXPECTED_TAR_FILENAME
+ARG DEPENDENCY_ARCHIVE_URL
+ARG GITHUB_USER
+
+RUN curl -LSs --fail -o /tmp/swaggen.tgz -- "${DEPENDENCY_ARCHIVE_URL}"     \
+    && cd /tmp                                                              \
+    && tar -xzf swaggen.tgz                                                 \
+    && mv "$(ls -d ${EXPECTED_TAR_FILENAME} | grep ${GITHUB_USER})" ./swaggen  \
+    && cd /tmp/swaggen                                                      \
+    && make install PREFIX=/tmp/swaggen-install
+
+# -----------------------------------------------------------------------------
+# RUN STAGE
+# -----------------------------------------------------------------------------
+
+FROM swift:slim
+LABEL maintainer="${MAINTAINER}"
+LABEL description="${DOCKER_IMAGE_DESCRIPTION}"
+
+COPY --from=builder /tmp/swaggen-install/ /usr/local/
+
+COPY Dockerfile /Dockerfile
+COPY LICENSE /LICENSE
+COPY VERSION /VERSION
+
+RUN chmod +x /usr/local/bin/swaggen
+
+###############################################################################

--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ import SwagGenKit
 import Swagger
 ```
 
+#### Use as Docker Image
+
+```bash
+# Pull this image
+docker pull yonaskolb/swaggen:latest
+
+declare DOCKER_MOUNTED_PATH="/tmp/workdir"
+
+curl https://www.mysite.com/swagger.json -o api.json
+
+# Run swaggen
+#   - This assumes your spec file is in $(pwd)/spec.json
+#   - Generated code will be available in $(pwd)/swaggen-output
+
+docker run                                                              \
+  --rm                                                                  \
+  -v "$(pwd):${DOCKER_MOUNTED_PATH}"                                    \
+  yonaskolb/swaggen:latest                                                 \
+  swaggen generate "${DOCKER_MOUNTED_PATH}/api.json"                    \
+  --language swift                                                      \
+  --template "${DOCKER_MOUNTED_PATH}/Templates/Swift/template.yml"      \
+  --destination "${DOCKER_MOUNTED_PATH}/Generated/Swift"                \
+  --clean all                                                           \
+  --verbose
+```
+
+
 ## Usage
 
 Use `--help` to see usage information

--- a/getLastSwiftTag.swift
+++ b/getLastSwiftTag.swift
@@ -1,0 +1,105 @@
+// GitHubTagElement.swift
+
+import Foundation
+import Version  // mrackwitz/Version
+
+extension String : Error, LocalizedError {
+  public var errorDescription: String? { get { self } }
+}
+
+extension Sequence {
+  func sorted<T: Comparable>(by keyPath: KeyPath<Element, T>) -> [Element] {
+    return sorted { a, b in
+      return a[keyPath: keyPath] < b[keyPath: keyPath]
+    }
+  }
+}
+
+// MARK: - GitHubTagElement
+public struct GitHubTagElement: Equatable, Codable {
+  public let ref: String?
+  public let nodeid: String?
+  public let url: String?
+  public let object: Commit?
+  public var name: String {
+    get { ref!.replacingOccurrences(of: "refs/tags/swift-", with: "") }
+  }
+  public var tagName: String {
+    get { ref!.replacingOccurrences(of: "refs/tags/", with: "") }
+  }
+  public var version: Version {
+    get {
+      var nName = name.replacingOccurrences(of: "-RELEASE", with: "")
+      return Version(nName)!
+    }
+  }
+}
+
+extension GitHubTagElement: Comparable {
+  public static func < (lhs: GitHubTagElement, rhs: GitHubTagElement) -> Bool {
+    return lhs.version < rhs.version
+  }
+
+  public static func > (lhs: GitHubTagElement, rhs: GitHubTagElement) -> Bool {
+    return lhs.version > rhs.version
+  }
+}
+
+// MARK: - Commit
+public struct Commit: Equatable, Codable {
+  public let sha: String?
+  public let type: String?
+  public let url: String?
+
+}
+
+func getTags(_ repo: String, _ releaseFilter: String, completion: @escaping (Result<String, Error>) -> ()) throws {
+  guard let url = URL(string: "https://api.github.com/repos/\(repo)/git/refs/tags") else {
+    throw ("Failed to generated URL")
+  }
+  let decoder = JSONDecoder()
+  decoder.keyDecodingStrategy = .convertFromSnakeCase
+  let semaphore = DispatchSemaphore(value: 0)
+  let dataTask = URLSession.shared.dataTask(with: url) { (data, resp, err) in
+    defer { semaphore.signal() }
+    if err != nil { completion(.failure(err!)); return }
+    guard let unwrapData = data else { completion(.failure("Data is invalid")); return }
+    do {
+      let tagElements = try decoder.decode([GitHubTagElement].self, from: unwrapData)
+      let releases = tagElements.filter { $0.name.contains(releaseFilter) ?? false }
+      let sortedReleases = releases.sorted(by: \.version)
+      guard let name = sortedReleases.last?.tagName else { completion(.failure("No release found")); return }
+      completion(.success(name))
+    }
+    catch {
+      completion(.failure(error));
+      return
+    }
+  }
+  dataTask.resume()
+  _ = semaphore.wait(timeout: .distantFuture)
+}
+
+func main(_ args: [String]) {
+  if args.count != 3 {
+    print("Bad number of argument. $>./getLastSwiftTag.swift \"apple/swift\" \"-RELEASE\"");
+    exit(EXIT_FAILURE)
+  }
+  do {
+    try getTags(args[1], args[2]) { result in
+      switch result {
+      case .success(let version):
+        print(version)
+      case .failure(let err):
+        print(err)
+        exit(EXIT_FAILURE)
+      }
+    }
+  }
+  catch {
+    print(error.localizedDescription);
+    exit(EXIT_FAILURE)
+  }
+}
+
+main(CommandLine.arguments)

--- a/updateDockerImage.sh
+++ b/updateDockerImage.sh
@@ -1,0 +1,133 @@
+# Manually set
+# THIS IS THE ONLY PART OF THE SCRIPT THAT WE SHOULD CHANGE IF NEEDED
+declare GITHUB_REPO="yonaskolb/SwagGen"
+declare TAG_OR_BRANCH="master"
+declare DOCKERHUB_USER="yonaskolb"
+declare DOCKERHUB_PROJECT="swaggen"
+declare MAINTAINER="Yonas Kolb(@yonaskolb)"
+declare SWIFT_VERSION_CUSTOM=""
+declare DOCKER_IMAGE_VERSION_ALIAS="latest"
+
+
+# PLEASE DON'T CHANGE CODE BEHIND THIS LINE
+
+#########################################################################################
+# DYNAMICALLY SET INPUTS																#
+#########################################################################################
+declare SWIFT_VERSION=$(swift sh getLastSwiftTag.swift "apple/swift" "-RELEASE")
+if [[ -n "${SWIFT_VERSION_CUSTOM}" ]]; then
+	SWIFT_VERSION="${SWIFT_VERSION_CUSTOM}"
+fi
+declare DEPENDENCY_VERSION="$(curl --silent "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+if [[ "${TAG_OR_BRANCH}" != "master" ]]; then
+	DEPENDENCY_VERSION="${TAG_OR_BRANCH}"
+fi
+declare GITHUB_USER="$(echo ${GITHUB_REPO} | cut -d"/" -f1)"
+declare GITHUB_PROJECT="$(echo ${GITHUB_REPO} | cut -d"/" -f2)"
+declare GITHUB_FULLURL="https://github.com/${GITHUB_REPO}"
+declare OLD_DEPENDENCY_VERSION="$(cat VERSION)"
+declare OLD_SWIFT_VERSION="$(cat SWIFT_VERSION)"
+declare EXPECTED_TAR_FILENAME="${GITHUB_USER}-${GITHUB_PROJECT}-*"
+declare DOCKERHUB_PROJECT_ACCOUNT="${DOCKERHUB_USER}/${DOCKERHUB_PROJECT}"
+declare DOCKER_IMAGE_VERSION="${DEPENDENCY_VERSION}-slim"
+declare DOCKER_IMAGE_DESCRIPTION="Slim docker image for ${GITHUB_PROJECT}(${DEPENDENCY_VERSION}) with ${SWIFT_VERSION}"
+declare DEPENDENCY_ARCHIVE_URL="${GITHUB_FULLURL}/tarball/${DEPENDENCY_VERSION}"
+declare FORCE_UPDATE=false
+
+# TEST for empty DEPENDENCY AND SWIFT VERSION
+if [[ -z "${OLD_DEPENDENCY_VERSION}" ]] || [[ -z "${OLD_SWIFT_VERSION}" ]]; then
+  echo "${DEPENDENCY_VERSION}" > VERSION
+  echo "${SWIFT_VERSION}" > SWIFT_VERSION
+  FORCE_UPDATE=true
+  OLD_SWIFT_VERSION="$(cat SWIFT_VERSION)"
+  OLD_DEPENDENCY_VERSION="$(cat VERSION)"
+  DOCKER_IMAGE_VERSION="${DEPENDENCY_VERSION}-slim"
+fi
+
+# Generated
+declare DOCKER_IMAGE_TAG="${DOCKERHUB_USER}/${DOCKERHUB_PROJECT}:${DOCKER_IMAGE_VERSION}"
+
+#########################################################################################
+# BUILD																					#
+#########################################################################################
+echo "Building Docker image 🐳🔨"
+echo "---------------------------"
+echo "Previous dependency version: ${OLD_DEPENDENCY_VERSION}\n"
+echo "Previous Swift version: ${OLD_SWIFT_VERSION}\n"
+
+if [[ "$FORCE_UPDATE" = true ]] || [[ "${DEPENDENCY_VERSION}" != "${OLD_DEPENDENCY_VERSION}" ]] || [[ "${SWIFT_VERSION}" != "${OLD_SWIFT_VERSION}" ]]; then
+
+  echo "Remove previous image"
+  echo "---------------------"
+  docker login
+  docker rmi -f ${DOCKERHUB_PROJECT_ACCOUNT}:${DOCKER_IMAGE_VERSION} || true
+
+  # Build
+  docker build                                                            \
+  --build-arg DEPENDENCY_ARCHIVE_URL="${DEPENDENCY_ARCHIVE_URL}"          \
+  --build-arg GITHUB_USER="${GITHUB_USER}"                                \
+  --build-arg EXPECTED_TAR_FILENAME="${EXPECTED_TAR_FILENAME}"            \
+  --build-arg MAINTAINER="${MAINTAINER}"                                  \
+  --build-arg DOCKER_IMAGE_DESCRIPTION="${DOCKER_IMAGE_DESCRIPTION}"      \
+  --force-rm                                                              \
+  --pull                                                                  \
+  --tag "${DOCKER_IMAGE_TAG}"                                             \
+  .
+
+  echo "FORCE_UPDATE: ${FORCE_UPDATE}"
+  echo "${DEPENDENCY_VERSION}" > VERSION
+  echo "${SWIFT_VERSION}" > SWIFT_VERSION
+
+else
+  echo "-- Last Build info"
+  echo "Swaggen: ${OLD_DEPENDENCY_VERSION}"
+  echo "Swift: ${OLD_SWIFT_VERSION}"
+  echo "No need to update 👍"
+  exit 0 # EXIT_SUCCESS
+fi
+
+#########################################################################################
+# TEST																					#
+#########################################################################################
+if [[ "${TAG_OR_BRANCH}" == "master" ]]; then
+
+echo "Testing ⚙️"
+echo "---------------------------"
+DEPENDENCY_TEST_VERSION=$(docker run --rm "${DOCKER_IMAGE_TAG}" swaggen --version)
+if [[ "Version: ${DEPENDENCY_VERSION}" == "${DEPENDENCY_TEST_VERSION}" ]]; then
+  echo "👍"
+else
+  echo "👎"
+fi
+
+fi
+
+#########################################################################################
+# TAG																					#
+#########################################################################################
+echo "Tag"
+echo "---------------------------"
+
+## Delete Tag
+git push --delete origin "${DOCKER_IMAGE_VERSION}" || true
+git tag -d "${DOCKER_IMAGE_VERSION}" || true
+
+## Push Tag
+git tag "${DOCKER_IMAGE_VERSION}" -m "${DEPENDENCY_VERSION}/${SWIFT_VERSION}"
+git push origin "${DOCKER_IMAGE_VERSION}"
+
+#########################################################################################
+# PUBLISH																				#
+#########################################################################################
+echo "Publish 🚀"
+echo "---------------------------"
+
+docker login
+if [[ "${TAG_OR_BRANCH}" != "master" ]]; then
+	docker tag	${DOCKERHUB_PROJECT_ACCOUNT}:${DOCKER_IMAGE_VERSION} "${DOCKERHUB_PROJECT_ACCOUNT}:${DOCKER_IMAGE_VERSION}-latest"
+	docker push ${DOCKERHUB_PROJECT_ACCOUNT}:${DOCKER_IMAGE_VERSION}
+else
+	docker tag	${DOCKERHUB_PROJECT_ACCOUNT}:${DOCKER_IMAGE_VERSION} ${DOCKERHUB_PROJECT_ACCOUNT}:${DOCKER_IMAGE_VERSION_ALIAS}
+	docker push ${DOCKERHUB_PROJECT_ACCOUNT}:${DOCKER_IMAGE_VERSION}
+	docker push ${DOCKERHUB_PROJECT_ACCOUNT}:${DOCKER_IMAGE_VERSION_ALIAS}
+fi


### PR DESCRIPTION
Let's restart the discussion around docker image support. This aim to replace https://github.com/yonaskolb/SwagGen/pull/163 and add support for docker for this projet.

## Why

After almost a year of working with Swaggen in a Docker container I do prefer this workflow. Because it guarantees that it is working the same way as your CI is working or if your backend dev are on Linux it works for them to too test if they didn't break your library.  With one script anyone(back/front end dev) in the team can generate a custom version of the library. It's easier to maintain and update. 

The generated images are 77mb of size and have everything required for swift and swaggen to work.

## How to use the generated image

```shell
# Pull this image
docker pull yonaskolb/swaggen:latest

declare DOCKER_MOUNTED_PATH="/tmp/workdir"

docker run                                                              \
  --rm                                                                  \
  -v "$(pwd):${DOCKER_MOUNTED_PATH}"                                    \
  yonaskolb/swaggen:latest                                                 \
  swaggen generate "${DOCKER_MOUNTED_PATH}/swagger.json"                \
  --language swift                                                      \
  --template "${DOCKER_MOUNTED_PATH}/Templates/Swift/template.yml"      \
  --destination "${DOCKER_MOUNTED_PATH}/ProjectXYZ" \
  --clean all                                                           \
  --verbose
```

## When to update it
You will need to update the Swaggen image for every new Swift build. But luckily it's a script to run with nothing to change in it and it will create/tag/publish everything.

## Change description
**getLastSwiftTag.swift** is a script that look for all the tag of a repo then search the one that match the pattern given in parameter(version of the Swift Toolchains for Linux released) then sort then and take the one with the bigger version number.
**updateDockerImage.sh** is the main script here it goal is to generate a new docker image base from the official swift docker image but it add swaggen to it. It designed to be run every time a new version of swift is available publicly or for every new version of Swaggen. It build tag test and push the image to docker hub. The way the script is done allow for easy customization it's pretty easy to build a docker image for a branch of a repo. I'm not great a shell script but it is doing the job pretty well.
**Docker.md** aims to the be central documentation point for docker matter.
**Dockerfile** is the recipe used to build the docker images it based on [mithun](https://github.com/mithun) work on the matter.

The way **updateDockerImage.sh** is written allow you to use it in other place pretty easily.

## Todo for the maintainer
In order for all of this to work @yonaskolb you have to make an account with **yonaskolb** username and create the project swaggen on it on https://hub.docker.com it's free for public docker image. Once it done please update the top of **updateDockerImage.sh** with what you chose as login and project. Then just run it.

## Other people do the same
[OpenAPI provide a Docker image](https://hub.docker.com/r/openapitools/openapi-generator-cli/) for their generator.

```shell
# Pull this image
docker pull docker pull openapitools/openapi-generator-cli:latest

declare DOCKER_MOUNTED_PATH="/tmp/workdir"

docker run                                                              \
  --rm                                                                  \
  -v "$(pwd):${DOCKER_MOUNTED_PATH}"                                    \
  openapitools/openapi-generator-cli:latest generate                    \
  -i "${DOCKER_MOUNTED_PATH}/swagger.json"                              \
  -g swift5                                                             \
  -o "${DOCKER_MOUNTED_PATH}/ProjectXYZ"                 \
  --verbose
```

I hope it helps.