### PR TITLE
Upgrade SwiftCLI dependency to the next major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - MediaItem schema is now defined as a possible reference in order to generate models of each server response. #239 @alexruperez
 
+### Changes
+- Updated SwiftCLI dependency to next major version #241
+
 ### Fixed
 - Fixed inline allOf group generation
 - Fixed property generation when there is only one group schema;  the first group schema type will be used as the type #217

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "df4d5b3ec2c1421a58d71010ff43528db5b19e04",
-          "version": "5.3.3"
+          "revision": "c72c4564f8c0a24700a59824880536aca45a4cae",
+          "version": "6.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/PathKit.git", from: "0.9.0"),
-        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.3.0"),
+        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "6.0.1"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.7.2"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "1.0.0"),
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "4.1.0"),


### PR DESCRIPTION
**Background**
I was trying to make my own command line tool making use of `SwagGenKit` and wanted to use the latest `SwiftCLI` version but could not due conflicting dependency version with `SwagGen`

**Changes**
- Update the command line tool to use the latest version of SwiftCLI; this replaces a lot type declarations with property wrappers and also allows us to use the option values directly without calling `.value`
