### PR TITLE
Fix a potential crash when constructing a URLRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+### Fixed
+- Fixed sporadic crashes due to malformed URLs #268 @marcelvoss
+
 ## 4.4.0
 
 ### Added

--- a/Templates/Swift/Sources/APIClient.swift
+++ b/Templates/Swift/Sources/APIClient.swift
@@ -50,7 +50,11 @@ public class APIClient {
         // create the url request from the request
         var urlRequest: URLRequest
         do {
-            urlRequest = try request.createURLRequest(baseURL: baseURL, encoder: jsonEncoder)
+            guard let safeURL = URL(string: baseURL) else {
+                throw InternalError.malformedURL
+            }
+
+            urlRequest = try request.createURLRequest(baseURL: safeURL, encoder: jsonEncoder)
         } catch {
             let error = APIClientError.requestEncodingError(error)
             requestBehaviour.onFailure(error: error)
@@ -151,7 +155,10 @@ public class APIClient {
         switch dataResponse.result {
         case .success(let value):
             do {
-                let statusCode = dataResponse.response!.statusCode
+                guard let statusCode = dataResponse.response?.statusCode else {
+                    throw InternalError.emptyResponse
+                }
+
                 let decoded = try T(statusCode: statusCode, data: value, decoder: jsonDecoder)
                 result = .success(decoded)
                 if decoded.successful {
@@ -184,6 +191,13 @@ public class APIClient {
     }
 }
 
+private extension APIClient {
+    enum InternalError: Error {
+        case malformedURL
+        case emptyResponse
+    }
+}
+
 public class CancellableRequest {
     /// The request used to make the actual network request
     public let request: AnyRequest
@@ -191,13 +205,12 @@ public class CancellableRequest {
     init(request: AnyRequest) {
         self.request = request
     }
+
     var networkRequest: Request?
 
     /// cancels the request
     public func cancel() {
-        if let networkRequest = networkRequest {
-            networkRequest.cancel()
-        }
+        networkRequest?.cancel()
     }
 }
 
@@ -213,33 +226,34 @@ extension APIRequest {
 // Create URLRequest
 extension APIRequest {
 
-    /// pass in an optional baseURL, otherwise URLRequest.url will be relative
-    public func createURLRequest(baseURL: String = "", encoder: RequestEncoder = JSONEncoder()) throws -> URLRequest {
-        let url = URL(string: "\(baseURL)\(path)")!
-        var urlRequest = URLRequest(url: url)
+    public func createURLRequest(baseURL: URL, encoder: RequestEncoder = JSONEncoder()) throws -> URLRequest {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(path))
         urlRequest.httpMethod = service.method
         urlRequest.allHTTPHeaderFields = headers
 
         // filter out parameters with empty string value
         var queryParams: [String: Any] = [:]
         for (key, value) in queryParameters {
-            if String.init(describing: value) != "" {
+            if !String(describing: value).isEmpty {
                 queryParams[key] = value
             }
         }
+
         if !queryParams.isEmpty {
             urlRequest = try URLEncoding.queryString.encode(urlRequest, with: queryParams)
         }
 
         var formParams: [String: Any] = [:]
         for (key, value) in formParameters {
-            if String.init(describing: value) != "" {
+            if !String(describing: value).isEmpty {
                 formParams[key] = value
             }
         }
+
         if !formParams.isEmpty {
             urlRequest = try URLEncoding.httpBody.encode(urlRequest, with: formParams)
         }
+
         if let encodeBody = encodeBody {
             urlRequest.httpBody = try encodeBody(encoder)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
Hi there,

we have discovered a crash in our Firebase integration that comes from APIClient.swift:L221 (a force unwrap of a URL) within multiple generated clients in our project, while we don't have incorrect/missing URLs being passed in here. Said crashes are occurring incredibly sporadic and only once or twice in a month (maybe due to freak conditions). Probably still the right call to avoid crashing.

This does a bit of a clean up by using best practices (such as non-explicit initializers as well as avoiding force unwrapping and throwing instead).

We're currently using this very same template. 