### PR TITLE
Fix typo seperate > separate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,7 +320,7 @@ This includes a large rewrite with a lot more test cases so many more specs shou
 ### Fixed
 - Removed symbols from generated filenames
 - Generate Floats as `Float` not `Double`
-- Fixed some array query parameters not joining their contents with the collectionFormat seperator (uses comma delimeted by default now if none is provided)
+- Fixed some array query parameters not joining their contents with the collectionFormat separator (uses comma delimited by default now if none is provided)
 - Arrays and dictionaries of enums are now encoded
 - Arrays of models are now encoded
 - Support for a default response with no schema

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -300,7 +300,7 @@ public class CodeFormatter {
         context["requestSchemas"] = requestSchemas
         context["formProperties"] = formProperties
 
-        // TODO: seperate
+        // TODO: separate
         context["nonBodyParams"] = params.map(getParameterContext) + formProperties // params and form properties
 
         let securityRequirements = operation.securityRequirements ?? spec.securityRequirements

--- a/Sources/SwagGenKit/Utilities.swift
+++ b/Sources/SwagGenKit/Utilities.swift
@@ -64,10 +64,10 @@ fileprivate let acronymStrings = ["URL"]
 
 extension String {
 
-    private func camelCased(seperator: String) -> String {
+    private func camelCased(separator: String) -> String {
 
         var index = 0
-        let components = self.components(separatedBy: seperator)
+        let components = self.components(separatedBy: separator)
         if uppercased() == self {
             return components.map { $0.lowercased().mapFirstChar { $0.uppercased() } }.joined(separator: "")
         }
@@ -95,11 +95,11 @@ extension String {
         return first + rest
     }
 
-    private func camelCaseSeperators() -> String {
+    private func camelCaseSeparators() -> String {
         var string = self
         for separator in separators {
             if string.contains(separator) {
-                string = string.camelCased(seperator: separator)
+                string = string.camelCased(separator: separator)
             }
         }
         return string
@@ -115,7 +115,7 @@ extension String {
 
     func lowerCamelCased() -> String {
 
-        let string = camelCaseSeperators()
+        let string = camelCaseSeparators()
 
         if string == string.uppercased(), !hasSeparator {
             return string.lowercased()
@@ -128,7 +128,7 @@ extension String {
         if acronymStrings.contains(uppercased()), !hasSeparator {
             return uppercased()
         }
-        return camelCaseSeperators().mapFirstChar { $0.uppercased() }
+        return camelCaseSeparators().mapFirstChar { $0.uppercased() }
     }
 }
 

--- a/Specs/TFL/spec.json
+++ b/Specs/TFL/spec.json
@@ -1076,7 +1076,7 @@
            {
              "name": "serviceTypes",
              "in": "query",
-             "description": "A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
+             "description": "A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
              "required": false,
              "explode": true,
              "schema": {
@@ -1156,7 +1156,7 @@
            {
              "name": "serviceTypes",
              "in": "query",
-             "description": "A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
+             "description": "A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
              "required": false,
              "explode": true,
              "schema": {
@@ -1236,7 +1236,7 @@
            {
              "name": "serviceTypes",
              "in": "query",
-             "description": "A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
+             "description": "A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
              "required": false,
              "explode": true,
              "schema": {
@@ -1327,7 +1327,7 @@
            {
              "name": "serviceTypes",
              "in": "query",
-             "description": "A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
+             "description": "A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
              "required": false,
              "explode": true,
              "schema": {
@@ -1592,7 +1592,7 @@
            {
              "name": "serviceTypes",
              "in": "query",
-             "description": "A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
+             "description": "A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified",
              "required": false,
              "explode": true,
              "schema": {
@@ -4610,7 +4610,7 @@
            {
              "name": "modes",
              "in": "path",
-             "description": "A comma-seperated list of modes e.g. tube,dlr",
+             "description": "A comma-separated list of modes e.g. tube,dlr",
              "required": true,
              "schema": {
                "type": "array",
@@ -4682,7 +4682,7 @@
            {
              "name": "ids",
              "in": "path",
-             "description": "A comma-seperated list of stop point ids. Max. approx. 20 ids.\r\n            You can use /StopPoint/Search/{query} endpoint to find a stop point id from a station name.",
+             "description": "A comma-separated list of stop point ids. Max. approx. 20 ids.\r\n            You can use /StopPoint/Search/{query} endpoint to find a stop point id from a station name.",
              "required": true,
              "schema": {
                "type": "array",
@@ -4962,7 +4962,7 @@
            {
              "name": "modes",
              "in": "path",
-             "description": "A comma-seperated list of modes e.g. tube,dlr",
+             "description": "A comma-separated list of modes e.g. tube,dlr",
              "required": true,
              "schema": {
                "type": "array",


### PR DESCRIPTION
Just some small misspelling fixes, no further changes.