### PR TITLE
Improve CodeFormatter efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+### Changed
+- Improved `CodeFormatter` efficiency #272 @zntfdr
+
 ### Fixed
 - Fixed sporadic crashes due to malformed URLs #268 @marcelvoss
 - Fixed generation of inline types for `allOf` #267

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Changed
 - Improved `CodeFormatter` efficiency #272 @zntfdr
-- `CodeFormatter`'s `getOperationContext(_:)` can now set `onlySuccessResponses` to `true` even when there are multiple success responses 
 
 ## 4.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Improved `CodeFormatter` efficiency #272 @zntfdr
+- `CodeFormatter`'s `getOperationContext(_:)` can now set `onlySuccessResponses` to `true` even when there are multiple success responses 
 
 ### Fixed
 - Fixed sporadic crashes due to malformed URLs #268 @marcelvoss

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -321,7 +321,7 @@ public class CodeFormatter {
         context["successResponse"] = successResponses.first
         context["successType"] = successResponses.first?["type"]
         context["defaultResponse"] = failureResponses.first { $0["statusCode"] == nil }
-        context["onlySuccessResponses"] = successResponses.count == responses.count
+        context["onlySuccessResponses"] = !successResponses.isEmpty && responses.count == 1
         context["alwaysHasResponseType"] = responses.filter { $0.response.value.schema != nil }.count == responses.count
 
         let successTypes = successResponses.compactMap { $0["type"] as? String }

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -165,17 +165,21 @@ public class CodeFormatter {
         context["isFile"] = schema.isFile
 
         if modelInheritance {
-            context["requiredProperties"] = schema.requiredProperties.map(getPropertyContext)
-            context["optionalProperties"] = schema.optionalProperties.map(getPropertyContext)
-            context["properties"] = schema.properties.map(getPropertyContext)
+            let requiredPropertiesContext = schema.requiredProperties.map(getPropertyContext)
+            let optionalPropertiesContext = schema.optionalProperties.map(getPropertyContext)
+            context["requiredProperties"] = requiredPropertiesContext
+            context["optionalProperties"] = optionalPropertiesContext
+            context["properties"] = requiredPropertiesContext + optionalPropertiesContext
             context["enums"] = schema.enums.map(getEnumContext)
             context["schemas"] = schema.properties.compactMap { property in
                 getInlineSchemaContext(property.schema, name: property.name)
             }
         } else {
-            context["requiredProperties"] = schema.inheritedRequiredProperties.map(getPropertyContext)
-            context["optionalProperties"] = schema.inheritedOptionalProperties.map(getPropertyContext)
-            context["properties"] = schema.inheritedProperties.map(getPropertyContext)
+            let inheritedRequiredPropertiesContext = schema.inheritedRequiredProperties.map(getPropertyContext)
+            let inheritedOptionalPropertiesContext = schema.inheritedOptionalProperties.map(getPropertyContext)
+            context["requiredProperties"] = inheritedRequiredPropertiesContext
+            context["optionalProperties"] = inheritedOptionalPropertiesContext
+            context["properties"] = inheritedRequiredPropertiesContext + inheritedOptionalPropertiesContext
             context["enums"] = schema.inheritedEnums.map(getEnumContext)
             context["schemas"] = schema.inheritedProperties.compactMap { property in
                 getInlineSchemaContext(property.schema, name: property.name)

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -310,15 +310,14 @@ public class CodeFormatter {
         // Responses
 
         let responses = operation.responses
-        let successResponse = responses.first { $0.successful }
         let successResponses = responses.filter { $0.successful }.map(getResponseContext)
         let failureResponses = responses.filter { !$0.successful }.map(getResponseContext)
 
         context["responses"] = responses.map(getResponseContext)
         context["successResponse"] = successResponses.first
-        context["successType"] = successResponse.flatMap(getResponseContext)?["type"]
+        context["successType"] = successResponses.first?["type"]
         context["defaultResponse"] = responses.first { $0.statusCode == nil }.flatMap(getResponseContext)
-        context["onlySuccessResponses"] = successResponse != nil && responses.count == 1
+        context["onlySuccessResponses"] = !successResponses.isEmpty && responses.count == 1
         context["alwaysHasResponseType"] = responses.filter { $0.response.value.schema != nil }.count == responses.count
 
         let successTypes = successResponses.compactMap { $0["type"] as? String }

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -321,7 +321,7 @@ public class CodeFormatter {
         context["successResponse"] = successResponses.first
         context["successType"] = successResponses.first?["type"]
         context["defaultResponse"] = failureResponses.first { $0["statusCode"] == nil }
-        context["onlySuccessResponses"] = !successResponses.isEmpty && responses.count == 1
+        context["onlySuccessResponses"] = successResponses.count == responses.count
         context["alwaysHasResponseType"] = responses.filter { $0.response.value.schema != nil }.count == responses.count
 
         let successTypes = successResponses.compactMap { $0["type"] as? String }

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -313,10 +313,10 @@ public class CodeFormatter {
         let successResponses = responses.filter { $0.successful }.map(getResponseContext)
         let failureResponses = responses.filter { !$0.successful }.map(getResponseContext)
 
-        context["responses"] = responses.map(getResponseContext)
+        context["responses"] = successResponses + failureResponses
         context["successResponse"] = successResponses.first
         context["successType"] = successResponses.first?["type"]
-        context["defaultResponse"] = responses.first { $0.statusCode == nil }.flatMap(getResponseContext)
+        context["defaultResponse"] = failureResponses.first { $0["statusCode"] == nil }
         context["onlySuccessResponses"] = !successResponses.isEmpty && responses.count == 1
         context["alwaysHasResponseType"] = responses.filter { $0.response.value.schema != nil }.count == responses.count
 


### PR DESCRIPTION
I've noticed that in `CodeFormatter`'s `getOperationContext(_:)` we can avoid calling `getResponseContext(_:)` a few times.

I'm working with a big `.yaml` file: 
In my testing this can save around 25% of memory use, and reduce `swaggen`'s execution by a few seconds as well.

No change in the final output