### PR TITLE
Correct typos in generated fixtures (#271)

### DIFF
--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineLineRoutesByIds.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineLineRoutesByIds.swift
@@ -12,7 +12,7 @@ extension TFL.Line {
 
         public static let service = APIService<Response>(id: "Line_LineRoutesByIds", tag: "Line", method: "GET", path: "/Line/{ids}/Route", hasBody: false, securityRequirements: [])
 
-        /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
         public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
             case regular = "Regular"
             case night = "Night"
@@ -25,7 +25,7 @@ extension TFL.Line {
                 /** A comma-separated list of line ids e.g. victoria,circle,N133. Max. approx. 20 ids. */
                 public var ids: [String]
 
-                /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+                /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
                 public var serviceTypes: [ServiceTypes]?
 
                 public init(ids: [String], serviceTypes: [ServiceTypes]? = nil) {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRoute.swift
@@ -12,7 +12,7 @@ extension TFL.Line {
 
         public static let service = APIService<Response>(id: "Line_Route", tag: "Line", method: "GET", path: "/Line/Route", hasBody: false, securityRequirements: [])
 
-        /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
         public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
             case regular = "Regular"
             case night = "Night"
@@ -22,7 +22,7 @@ extension TFL.Line {
 
             public struct Options {
 
-                /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+                /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
                 public var serviceTypes: [ServiceTypes]?
 
                 public init(serviceTypes: [ServiceTypes]? = nil) {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteByMode.swift
@@ -12,7 +12,7 @@ extension TFL.Line {
 
         public static let service = APIService<Response>(id: "Line_RouteByMode", tag: "Line", method: "GET", path: "/Line/Mode/{modes}/Route", hasBody: false, securityRequirements: [])
 
-        /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
         public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
             case regular = "Regular"
             case night = "Night"
@@ -25,7 +25,7 @@ extension TFL.Line {
                 /** A comma-separated list of modes e.g. tube,dlr */
                 public var modes: [String]
 
-                /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+                /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
                 public var serviceTypes: [ServiceTypes]?
 
                 public init(modes: [String], serviceTypes: [ServiceTypes]? = nil) {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteSequence.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteSequence.swift
@@ -19,7 +19,7 @@ extension TFL.Line {
             case all = "all"
         }
 
-        /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
         public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
             case regular = "Regular"
             case night = "Night"
@@ -35,7 +35,7 @@ extension TFL.Line {
                 /** The direction of travel. Can be inbound or outbound. */
                 public var direction: Direction
 
-                /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+                /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
                 public var serviceTypes: [ServiceTypes]?
 
                 /** That excludes crowding from line disruptions. Can be true or false. */

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineSearch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineSearch.swift
@@ -12,7 +12,7 @@ extension TFL.Line {
 
         public static let service = APIService<Response>(id: "Line_Search", tag: "Line", method: "GET", path: "/Line/Search/{query}", hasBody: false, securityRequirements: [])
 
-        /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+        /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
         public enum ServiceTypes: String, Codable, Equatable, CaseIterable {
             case regular = "Regular"
             case night = "Night"
@@ -28,7 +28,7 @@ extension TFL.Line {
                 /** Optionally filter by the specified modes */
                 public var modes: [String]?
 
-                /** A comma seperated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
+                /** A comma separated list of service types to filter on. Supported values: Regular, Night. Defaulted to 'Regular' if not specified */
                 public var serviceTypes: [ServiceTypes]?
 
                 public init(query: String, modes: [String]? = nil, serviceTypes: [ServiceTypes]? = nil) {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDisruption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDisruption.swift
@@ -16,7 +16,7 @@ extension TFL.StopPoint {
 
             public struct Options {
 
-                /** A comma-seperated list of stop point ids. Max. approx. 20 ids.
+                /** A comma-separated list of stop point ids. Max. approx. 20 ids.
             You can use /StopPoint/Search/{query} endpoint to find a stop point id from a station name. */
                 public var ids: [String]
 

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDisruptionByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointDisruptionByMode.swift
@@ -16,7 +16,7 @@ extension TFL.StopPoint {
 
             public struct Options {
 
-                /** A comma-seperated list of modes e.g. tube,dlr */
+                /** A comma-separated list of modes e.g. tube,dlr */
                 public var modes: [String]
 
                 public var includeRouteBlockedStops: Bool?

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByMode.swift
@@ -16,7 +16,7 @@ extension TFL.StopPoint {
 
             public struct Options {
 
-                /** A comma-seperated list of modes e.g. tube,dlr */
+                /** A comma-separated list of modes e.g. tube,dlr */
                 public var modes: [String]
 
                 /** The data set page to return. Page 1 equates to the first 1000 stop points, page 2 equates to 1001-2000 etc. Must be entered for bus mode as data set is too large. */


### PR DESCRIPTION
#271 fixed a series of typos but didn't update the fixtures/generated source so CI checks are failing because of the mismatch. This PR updates the generated code to correct the typos (and thus ✅ the build)