### PR TITLE
Don't generate inline schemas when `allOf` only contains a single schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Fixed sporadic crashes due to malformed URLs #268 @marcelvoss
-- Fixed generation of inline types for `allOf` #267
+- Fixed generation of inline types for `allOf` #267 @nicholascross, @liamnichols
 
 ## 4.4.0
 

--- a/Sources/SwagGenKit/SwaggerExtensions.swift
+++ b/Sources/SwagGenKit/SwaggerExtensions.swift
@@ -156,7 +156,7 @@ extension Schema {
         case let .group(group):
             if group.discriminator != nil {
                 return self
-            } else if case .all = group.type {
+            } else if case .all = group.type, group.schemas.count > 1 {
                 return self
             }
         default: break

--- a/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift
@@ -9,8 +9,12 @@ public class UserSubclass: User {
 
     public var age: Int?
 
-    public init(id: Int? = nil, name: String? = nil, age: Int? = nil) {
+    /** last error reported to user object, or null if they have not seen an error. */
+    public var lastError: ErrorType?
+
+    public init(id: Int? = nil, name: String? = nil, age: Int? = nil, lastError: ErrorType? = nil) {
         self.age = age
+        self.lastError = lastError
         super.init(id: id, name: name)
     }
 
@@ -18,6 +22,7 @@ public class UserSubclass: User {
         let container = try decoder.container(keyedBy: StringCodingKey.self)
 
         age = try container.decodeIfPresent("age")
+        lastError = try container.decodeIfPresent("last_error")
         try super.init(from: decoder)
     }
 
@@ -25,12 +30,14 @@ public class UserSubclass: User {
         var container = encoder.container(keyedBy: StringCodingKey.self)
 
         try container.encodeIfPresent(age, forKey: "age")
+        try container.encodeIfPresent(lastError, forKey: "last_error")
         try super.encode(to: encoder)
     }
 
     override public func isEqual(to object: Any?) -> Bool {
       guard let object = object as? UserSubclass else { return false }
       guard self.age == object.age else { return false }
+      guard self.lastError == object.lastError else { return false }
       return super.isEqual(to: object)
     }
 }

--- a/Specs/TestSpec/generated/Swift/Sources/Models/Zoo.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/Zoo.swift
@@ -15,6 +15,8 @@ public class Zoo: APIModel {
 
     public var inlineAnimals: [InlineAnimals]?
 
+    public var manager: Manager?
+
     public var oneOfDog: Dog?
 
     public var schemaAnimals: [SingleAnimal]?
@@ -47,11 +49,73 @@ public class Zoo: APIModel {
         }
     }
 
-    public init(allOfDog: Dog? = nil, anyOfDog: Dog? = nil, inlineAnimal: Animal? = nil, inlineAnimals: [InlineAnimals]? = nil, oneOfDog: Dog? = nil, schemaAnimals: [SingleAnimal]? = nil) {
+    public class Manager: User {
+
+        public var value: Value?
+
+        public class Value: APIModel {
+
+            public var id: String
+
+            public init(id: String) {
+                self.id = id
+            }
+
+            public required init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: StringCodingKey.self)
+
+                id = try container.decode("id")
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: StringCodingKey.self)
+
+                try container.encode(id, forKey: "id")
+            }
+
+            public func isEqual(to object: Any?) -> Bool {
+              guard let object = object as? Value else { return false }
+              guard self.id == object.id else { return false }
+              return true
+            }
+
+            public static func == (lhs: Value, rhs: Value) -> Bool {
+                return lhs.isEqual(to: rhs)
+            }
+        }
+
+        public init(id: Int? = nil, name: String? = nil, value: Value? = nil) {
+            self.value = value
+            super.init(id: id, name: name)
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: StringCodingKey.self)
+
+            value = try container.decodeIfPresent("value")
+            try super.init(from: decoder)
+        }
+
+        public override func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: StringCodingKey.self)
+
+            try container.encodeIfPresent(value, forKey: "value")
+            try super.encode(to: encoder)
+        }
+
+        override public func isEqual(to object: Any?) -> Bool {
+          guard let object = object as? Manager else { return false }
+          guard self.value == object.value else { return false }
+          return super.isEqual(to: object)
+        }
+    }
+
+    public init(allOfDog: Dog? = nil, anyOfDog: Dog? = nil, inlineAnimal: Animal? = nil, inlineAnimals: [InlineAnimals]? = nil, manager: Manager? = nil, oneOfDog: Dog? = nil, schemaAnimals: [SingleAnimal]? = nil) {
         self.allOfDog = allOfDog
         self.anyOfDog = anyOfDog
         self.inlineAnimal = inlineAnimal
         self.inlineAnimals = inlineAnimals
+        self.manager = manager
         self.oneOfDog = oneOfDog
         self.schemaAnimals = schemaAnimals
     }
@@ -63,6 +127,7 @@ public class Zoo: APIModel {
         anyOfDog = try container.decodeIfPresent("anyOfDog")
         inlineAnimal = try container.decodeIfPresent("inlineAnimal")
         inlineAnimals = try container.decodeArrayIfPresent("inlineAnimals")
+        manager = try container.decodeIfPresent("manager")
         oneOfDog = try container.decodeIfPresent("oneOfDog")
         schemaAnimals = try container.decodeArrayIfPresent("schemaAnimals")
     }
@@ -74,6 +139,7 @@ public class Zoo: APIModel {
         try container.encodeIfPresent(anyOfDog, forKey: "anyOfDog")
         try container.encodeIfPresent(inlineAnimal, forKey: "inlineAnimal")
         try container.encodeIfPresent(inlineAnimals, forKey: "inlineAnimals")
+        try container.encodeIfPresent(manager, forKey: "manager")
         try container.encodeIfPresent(oneOfDog, forKey: "oneOfDog")
         try container.encodeIfPresent(schemaAnimals, forKey: "schemaAnimals")
     }
@@ -84,6 +150,7 @@ public class Zoo: APIModel {
       guard self.anyOfDog == object.anyOfDog else { return false }
       guard self.inlineAnimal == object.inlineAnimal else { return false }
       guard self.inlineAnimals == object.inlineAnimals else { return false }
+      guard self.manager == object.manager else { return false }
       guard self.oneOfDog == object.oneOfDog else { return false }
       guard self.schemaAnimals == object.schemaAnimals else { return false }
       return true

--- a/Specs/TestSpec/generated/Swift/Sources/Models/Zoo.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/Zoo.swift
@@ -19,46 +19,6 @@ public class Zoo: APIModel {
 
     public var schemaAnimals: [SingleAnimal]?
 
-    public class AllOfDog: Dog {
-
-        public override init(animal: String? = nil, barks: Bool? = nil) {
-            super.init(animal: animal, barks: barks)
-        }
-
-        public required init(from decoder: Decoder) throws {
-            try super.init(from: decoder)
-        }
-
-        public override func encode(to encoder: Encoder) throws {
-            try super.encode(to: encoder)
-        }
-
-        override public func isEqual(to object: Any?) -> Bool {
-          guard object is AllOfDog else { return false }
-          return super.isEqual(to: object)
-        }
-    }
-
-    public class InlineAnimal: Animal {
-
-        public override init(animal: String? = nil) {
-            super.init(animal: animal)
-        }
-
-        public required init(from decoder: Decoder) throws {
-            try super.init(from: decoder)
-        }
-
-        public override func encode(to encoder: Encoder) throws {
-            try super.encode(to: encoder)
-        }
-
-        override public func isEqual(to object: Any?) -> Bool {
-          guard object is InlineAnimal else { return false }
-          return super.isEqual(to: object)
-        }
-    }
-
     public enum InlineAnimals: Codable, Equatable {
         case cat(Cat)
         case dog(Dog)

--- a/Specs/TestSpec/spec.yml
+++ b/Specs/TestSpec/spec.yml
@@ -240,6 +240,11 @@ components:
           properties:
             age:
               type: integer
+            last_error:
+              allOf:
+                - $ref: "#/components/schemas/Error"
+              nullable: true
+              description: last error reported to user object, or null if they have not seen an error.
     UserReference:
       $ref: "#/components/schemas/User"
     ModelWithAdditionalProperties:

--- a/Specs/TestSpec/spec.yml
+++ b/Specs/TestSpec/spec.yml
@@ -337,6 +337,17 @@ components:
         allOfDog:
             allOf:
                 - $ref: '#/components/schemas/Dog'
+        manager:
+          allOf:
+            - $ref: "#/components/schemas/User"
+            - properties:
+                value:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      type: string
     SingleAnimal:
       oneOf:
         - $ref: "#/components/schemas/Cat"


### PR DESCRIPTION
This relates to the patch applied in #269, which in turn relates to #267. cc @nicholascross, @ymhuang0808. Firstly please excuse me if i missed some important historical context but I'm just trying to solve a slightly different regression that I noticed in some of my own examples.

In #269, we reintroduced inline generation for `allOf` types however in turn this introduced this diff: https://github.com/yonaskolb/SwagGen/pull/269/files#diff-6582636d47b022b95a7a5dfd79ff1e767f5f862e5eba00c00eb46208c5e7aab1

I believe that this is separate to the original issue however since `Zoo.AllOfDog` and `Zoo.InlineAnimal` go unused and this is related to the issue that I am seeing with my schema.

If we take the following: 

```yml
UserSubclass:
  allOf:
    - $ref: "#/components/schemas/User"
    - type: object
      properties:
        age:
          type: integer
        last_error:
          allOf:
            - $ref: "#/components/schemas/Error"
          nullable: true
          description: last error reported to user object, or null if they have not seen an error.
```

The intention of the `last_error` property is to reference an existing schema (`Error`) but to override its nullability and/or description when used within `UserSubclass` since its likely that these two properties on the schema (and possibly more) will vary. My understanding is that this approach is [commonly used](https://stackoverflow.com/a/48114924) and i've seen other generators working with it.

In fact, SwagGen was already properly resolving the property types to `Animal` and `Dog` as expected (hence why the inline types went unused) thanks to this:

https://github.com/yonaskolb/SwagGen/blob/76d42a66befce35a83cd2220dec3a654eebe08e0/Sources/SwagGenKit/SwiftFormatter.swift#L156-L162

As a result, my change ensures that `inlineSchema` is only returned if `group.schemas.count > 1` and this means that the unused `LastError` inline type would be omitted again:

<details>
<summary><b>Before</b></summary>

```diff
diff --git a/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift b/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift
index d11ebc7..a6414ef 100644
--- a/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift
@@ -9,8 +9,33 @@ public class UserSubclass: User {
 
     public var age: Int?
 
-    public init(id: Int? = nil, name: String? = nil, age: Int? = nil) {
+    /** last error reported to user object, or null if they have not seen an error. */
+    public var lastError: ErrorType?
+
+    /** last error reported to user object, or null if they have not seen an error. */
+    public class LastError: ErrorType {
+
+        public override init(code: Int, message: String) {
+            super.init(code: code, message: message)
+        }
+
+        public required init(from decoder: Decoder) throws {
+            try super.init(from: decoder)
+        }
+
+        public override func encode(to encoder: Encoder) throws {
+            try super.encode(to: encoder)
+        }
+
+        override public func isEqual(to object: Any?) -> Bool {
+          guard object is LastError else { return false }
+          return super.isEqual(to: object)
+        }
+    }
+
+    public init(id: Int? = nil, name: String? = nil, age: Int? = nil, lastError: ErrorType? = nil) {
         self.age = age
+        self.lastError = lastError
         super.init(id: id, name: name)
     }
 
@@ -18,6 +43,7 @@ public class UserSubclass: User {
         let container = try decoder.container(keyedBy: StringCodingKey.self)
 
         age = try container.decodeIfPresent("age")
+        lastError = try container.decodeIfPresent("last_error")
         try super.init(from: decoder)
     }
 
@@ -25,12 +51,14 @@ public class UserSubclass: User {
         var container = encoder.container(keyedBy: StringCodingKey.self)
 
         try container.encodeIfPresent(age, forKey: "age")
+        try container.encodeIfPresent(lastError, forKey: "last_error")
         try super.encode(to: encoder)
     }
 
     override public func isEqual(to object: Any?) -> Bool {
       guard let object = object as? UserSubclass else { return false }
       guard self.age == object.age else { return false }
+      guard self.lastError == object.lastError else { return false }
       return super.isEqual(to: object)
     }
 }
```

</details>

<details>
<summary><b>After</b></summary>

```diff
diff --git a/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift b/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift
index d11ebc7..d34e692 100644
--- a/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/UserSubclass.swift
@@ -9,8 +9,12 @@ public class UserSubclass: User {
 
     public var age: Int?
 
-    public init(id: Int? = nil, name: String? = nil, age: Int? = nil) {
+    /** last error reported to user object, or null if they have not seen an error. */
+    public var lastError: ErrorType?
+
+    public init(id: Int? = nil, name: String? = nil, age: Int? = nil, lastError: ErrorType? = nil) {
         self.age = age
+        self.lastError = lastError
         super.init(id: id, name: name)
     }
 
@@ -18,6 +22,7 @@ public class UserSubclass: User {
         let container = try decoder.container(keyedBy: StringCodingKey.self)
 
         age = try container.decodeIfPresent("age")
+        lastError = try container.decodeIfPresent("last_error")
         try super.init(from: decoder)
     }
 
@@ -25,12 +30,14 @@ public class UserSubclass: User {
         var container = encoder.container(keyedBy: StringCodingKey.self)
 
         try container.encodeIfPresent(age, forKey: "age")
+        try container.encodeIfPresent(lastError, forKey: "last_error")
         try super.encode(to: encoder)
     }
 
     override public func isEqual(to object: Any?) -> Bool {
       guard let object = object as? UserSubclass else { return false }
       guard self.age == object.age else { return false }
+      guard self.lastError == object.lastError else { return false }
       return super.isEqual(to: object)
     }
 }

```

</details>

As for the original issue reported in #267, I updated TestSpec in c10a5e693df9a24fe5b2ce3131ac777202da5b29 to include the expected results described by @ymhuang0808 (at least I think I did 😅) so hopefully the updated fixtures describe fixes to both issues... Please confirm though! 

Thanks 🙇 
