### PR TITLE
Updated PathKit and SwiftCLI to latest versions to fix compiling issues

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,30 @@
         }
       },
       {
+        "package": "Komondor",
+        "repositoryURL": "https://github.com/shibapm/Komondor.git",
+        "state": {
+          "branch": null,
+          "revision": "1bb467ad7ad57e94af82d73fa0fe063cb0b8ddd5",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "PackageConfig",
+        "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
+        "state": {
+          "branch": null,
+          "revision": "bf90dc69fa0792894b08a0b74cf34029694ae486",
+          "version": "0.13.0"
+        }
+      },
+      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -29,12 +47,21 @@
         }
       },
       {
+        "package": "ShellOut",
+        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
+        "state": {
+          "branch": null,
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
+        }
+      },
+      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
@@ -42,8 +69,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "0e9a78d6584e3812cd9c09494d5c7b483e8f533c",
-          "version": "0.13.1"
+          "revision": "973e190edf5d09274e4a6bc2e636c86899ed84c3",
+          "version": "0.14.1"
         }
       },
       {
@@ -51,8 +78,8 @@
         "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
         "state": {
           "branch": null,
-          "revision": "dbf02bd6afe71b65ead2bd250aaf974abc688094",
-          "version": "2.7.2"
+          "revision": "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
+          "version": "2.8.0"
         }
       },
       {
@@ -60,8 +87,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "df4d5b3ec2c1421a58d71010ff43528db5b19e04",
-          "version": "5.3.3"
+          "revision": "2e949055d9797c1a6bddcda0e58dada16cc8e970",
+          "version": "6.0.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
         .library(name: "Swagger", targets: ["Swagger"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/kylef/PathKit.git", from: "0.9.0"),
-        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.3.0"),
+        .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
+        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "6.0.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.7.2"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "4.1.0"),

--- a/Sources/SwagGen/GenerateCommand.swift
+++ b/Sources/SwagGen/GenerateCommand.swift
@@ -11,7 +11,7 @@ class GenerateCommand: Command {
     let name = "generate"
     let shortDescription = "Generates code for a Swagger spec"
 
-    let spec = SwiftCLI.Parameter()
+    let spec = SwiftCLI.Param<String>()
 
     let clean = Key<Generator.Clean>("--clean", "-c", description: """
         How the destination directory will be cleaned of non generated files:
@@ -33,8 +33,11 @@ class GenerateCommand: Command {
         for example, --option "typeAliases.ID:String" would change the type alias of ID to String.
         """)
 
-    let verbose = Flag("--verbose", "-v", description: "Show verbose output", defaultValue: false)
-    let silent = Flag("--silent", "-s", description: "Silence standard output", defaultValue: false)
+    @Flag("--verbose", "-v", description: "Show verbose output")
+    var verbose: Bool
+    
+    @Flag("--silent", "-s", description: "Silence standard output")
+    var silent: Bool
 
     func execute() throws {
         let clean = self.clean.value ?? .none
@@ -113,7 +116,7 @@ class GenerateCommand: Command {
     }
 
     func standardOut(_ string: String) {
-        if !silent.value {
+        if !silent {
             stdout <<< string
         }
     }
@@ -163,7 +166,7 @@ class GenerateCommand: Command {
         )
         standardOut("Loaded template: \(templateCounts)")
 
-        if verbose.value {
+        if verbose {
             if !templateConfig.options.isEmpty {
                 standardOut("Options:\n  \(templateConfig.options.prettyPrinted.replacingOccurrences(of: "\n", with: "\n  "))")
             }
@@ -199,7 +202,7 @@ class GenerateCommand: Command {
         do {
             let generationResult = try generator.generate(clean: clean) { change in
 
-                guard verbose.value else {
+                guard verbose else {
                     return
                 }
 


### PR DESCRIPTION
After updating to Xcode 13, building SwagGen fails because of the PathKit and SwiftCLI dependencies. These issues are fixed in the latest versions of those dependencies, so this PR updates them. As SwiftCLI has updated to a new major versions, some small changes had to be made in order to make it work again.