### PR TITLE
Fix make uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install: build
 
 uninstall:
 	rm -f $(INSTALL_PATH)
-	rm -f $(SHARE_PATH)
+	rm -rf $(SHARE_PATH)
 
 format_code:
 	swiftformat Tests --wraparguments beforefirst --stripunusedargs closure-only --header strip --disable blankLinesAtStartOfScope


### PR DESCRIPTION
SHARE_PATH is a directory, so we need rm -r