### PR TITLE
[297]Remove implicit mapping when an explicit is present in the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Fixed compilation with Xcode 13 #282 @sroebert
+- Fixed duplicated switch cases when using explicit mappings in oneOf discriminator #297 @JanC
 
 ### Changed
 - Improved `CodeFormatter` efficiency #272 @zntfdr

--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -213,6 +213,7 @@ public class CodeFormatter {
                     for (key, value) in discriminatorMapping {
                         // TODO: could reference another spec
                         let reference = Reference<Schema>(value)
+                        mapping.removeValue(forKey: reference.name)
                         mapping[key] = getReferenceContext(reference)
                     }
                 }

--- a/Specs/TestSpec/generated/Swift/Sources/Models/SingleAnimal.swift
+++ b/Specs/TestSpec/generated/Swift/Sources/Models/SingleAnimal.swift
@@ -13,10 +13,6 @@ public enum SingleAnimal: Codable, Equatable {
         let container = try decoder.container(keyedBy: StringCodingKey.self)
         let discriminator: String = try container.decode("type")
         switch discriminator {
-        case "Cat":
-            self = .cat(try Cat(from: decoder))
-        case "Dog":
-            self = .dog(try Dog(from: decoder))
         case "cat":
             self = .cat(try Cat(from: decoder))
         case "dog":


### PR DESCRIPTION
As explained in #297, this PR removes the implicit case when an explicit mapping is present in a `discriminator`

fixes #297 