### PR TITLE
Fix number/integer enum case formatting

### DIFF
--- a/Sources/SwagGenKit/CodeFormatter.swift
+++ b/Sources/SwagGenKit/CodeFormatter.swift
@@ -454,7 +454,7 @@ public class CodeFormatter {
         }
         var enumCases: [[String: String]] = []
         for (index, value) in enumValue.cases.enumerated() {
-            let value = String(describing: value)
+            let value = self.enumValue(from: value)
             var name = value
             if let names = enumValue.names,
                 enumValue.cases.count == names.count {
@@ -470,6 +470,15 @@ public class CodeFormatter {
         context["raw"] = enumValue.metadata.json
         context["type"] = getSchemaType(name: "", schema: enumValue.schema, checkEnum: false)
         return context
+    }
+
+    private func enumValue(from caseValue: Any) -> String {
+        // `String(describing:` will not give a correct description for NSNumber value, use instead `NSNumber` string value:
+        if let number = caseValue as? NSNumber {
+            return String(describing: number.stringValue)
+        } else {
+            return String(describing: caseValue)
+        }
     }
 
     func escapeString(_ string: String) -> String {


### PR DESCRIPTION
`CodeFormatter` uses `String(describing:` to generate value and case names if no enum names are provided. This results in wrong integer enumations that do not compile:

Take the following spec
```
"foo: {
     "type": "integer",
      "enum": [
            1,
            2,
            3
       ],
 }
```
Currently, it will generate:
```
enum Foo: Int, Codable, Equatable, CaseIterable {
    case `true` = true
    case _20 = 2.0
    case _30 = 3.0
}
```

This MR fixes the issue by leveraging the `stringValue` property from `NSNumber`.
```
enum Foo: Int, Codable, Equatable, CaseIterable {
    case _1 = 1
    case _2 = 2
    case _3 = 3
}
```