### PR TITLE
Fix generated Readme

### DIFF
--- a/Templates/Swift/README.md
+++ b/Templates/Swift/README.md
@@ -74,7 +74,7 @@ apiClient.makeRequest(getUserRequest) { apiResponse in
 }
 ```
 
-Each [Request](#request) also has a `makeRequest` convenience function that uses `{{ options.name }}.shared`.
+Each [Request](#request) also has a `makeRequest` convenience function that uses `{{ options.name }}.default`.
 
 #### APIResponse
 The `APIResponse` that gets passed to the completion closure contains the following properties:


### PR DESCRIPTION
The default client is stored at `.default` instead of `.shared`