### PR TITLE
Support external references

### DIFF
--- a/Sources/Swagger/Component/ComponentResolver.swift
+++ b/Sources/Swagger/Component/ComponentResolver.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Yams
+import JSONUtilities
 
 #if !swift(>=4.2)
     public protocol CaseIterable {
@@ -7,117 +9,176 @@ import Foundation
 #endif
 
 class ComponentResolver {
+    
+    static var schemeURL: URL?
 
-    let spec: SwaggerSpec
+    var spec: SwaggerSpec
 
     var components: Components {
-        return spec.components
+        get { spec.components }
+        set { spec.components = newValue }
     }
 
     init(spec: SwaggerSpec) {
         self.spec = spec
     }
 
-    func resolve() {
+    func resolve() throws {
 
-        resolve(components.schemas, resolve)
-        resolve(components.parameters, resolve)
-        resolve(components.requestBodies, resolve)
-        resolve(components.headers, resolve)
-        resolve(components.requestBodies, resolve)
+        try resolve(components.schemas, resolve)
+        try resolve(components.parameters, resolve)
+        try resolve(components.requestBodies, resolve)
+        try resolve(components.headers, resolve)
+        try resolve(components.requestBodies, resolve)
 
-        spec.paths.forEach { path in
-            path.parameters.forEach(resolve)
-            path.operations.forEach { operation in
-                operation.pathParameters.forEach(resolve)
-                operation.operationParameters.forEach(resolve)
-                operation.responses.forEach(resolve)
+        try spec.paths.forEach { path in
+            try path.parameters.forEach(resolve)
+            try path.operations.forEach { operation in
+                try operation.pathParameters.forEach(resolve)
+                try operation.operationParameters.forEach(resolve)
+                try operation.responses.forEach(resolve)
                 if let requestBody = operation.requestBody {
-                    resolveReference(requestBody, objects: components.requestBodies)
-                    resolve(requestBody.value.content)
+                    try resolveReference(requestBody, objects: &components.requestBodies, resolve)
+                    try resolve(requestBody.value.content)
                 }
             }
         }
     }
-
-    private func resolveReference<T>(_ reference: Reference<T>, objects: [ComponentObject<T>]) {
+    
+    private func resolveReference<T>(_ reference: Reference<T>, objects: inout [ComponentObject<T>], _ resolver: (T) throws -> Void) throws {
         if reference.referenceType == T.componentType.rawValue,
-            let name = reference.referenceName,
-            let object = objects.first(where: { $0.name == name }) {
+           let name = reference.referenceName,
+           let object = objects.first(where: { $0.name == name }) {
             reference.resolve(with: object.value)
+        } else {
+            try resolveReference(reference, resolver)
+            objects.append(reference.component)
         }
     }
-
-    private func resolveReference<T: Component>(_ reference: PossibleReference<T>, objects: [ComponentObject<T>]) {
+    
+    private func resolveReference<T: Component>(_ reference: PossibleReference<T>, objects: inout [ComponentObject<T>], _ resolver: (T) throws -> Void) throws {
         if case let .reference(reference) = reference {
-            resolveReference(reference, objects: objects)
+            try resolveReference(reference, objects: &objects, resolver)
+        } else if case .value(let value) = reference {
+            try resolver(value)
         }
     }
-
-    private func resolve(_ schema: SchemaType) {
+    
+    private func resolveReference<T>(_ reference: PossibleReference<T>, _ resolver: (T) throws -> Void) throws {
+        if case let .reference(reference) = reference {
+            try resolveReference(reference, resolver)
+        } else if case .value(let value) = reference {
+            try resolver(value)
+        }
+    }
+    
+    private func resolveReference<T: JSONObjectConvertible>(_ reference: Reference<T>, _ resolver: (T) throws -> Void) throws {
+        guard reference.string.hasSuffix("yaml") else {
+            return
+        }
+        let url = try url(for: reference.string)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw SwaggerError.loadError(url)
+        }
+        let string = String(data: data, encoding: .utf8) ?? ""
+        let yaml = try Yams.load(yaml: string)
+        let json = yaml as? JSONDictionary ?? [:]
+        let value = try T.init(jsonDictionary: json)
+        reference.resolve(with: value)
+        let currentURL = ComponentResolver.schemeURL
+        ComponentResolver.schemeURL = url
+        try resolver(reference.value)
+        ComponentResolver.schemeURL = currentURL
+    }
+    
+    private func resolve(_ schema: SchemaType) throws {
         switch schema {
-        case let .reference(reference): resolveReference(reference, objects: components.schemas)
+        case let .reference(reference): try resolveReference(reference, objects: &components.schemas) { _ in }
         case let .object(object):
-            object.properties.forEach { resolve($0.schema) }
+            try object.properties.forEach { try resolve($0.schema) }
             if let additionalProperties = object.additionalProperties {
-                resolve(additionalProperties)
+                try resolve(additionalProperties)
             }
-        case let .group(schemaGroup): schemaGroup.schemas.forEach(resolve)
+        case let .group(schemaGroup): try schemaGroup.schemas.forEach(resolve)
         case let .array(array):
             switch array.items {
-            case let .single(schema): resolve(schema)
-            case let .multiple(schemas): schemas.forEach(resolve)
+            case let .single(schema): try resolve(schema)
+            case let .multiple(schemas): try schemas.forEach(resolve)
             }
         default: break
         }
     }
 
-    private func resolve(_ mediaItem: MediaItem) {
-        resolve(mediaItem.schema)
+    private func resolve(_ mediaItem: MediaItem) throws {
+        try resolve(mediaItem.schema)
     }
 
-    private func resolve(_ content: Content) {
+    private func resolve(_ content: Content) throws {
         for mediaItem in content.mediaItems.values {
-            resolve(mediaItem)
+            try resolve(mediaItem)
         }
     }
 
-    private func resolve(_ header: Header) {
-        resolve(header.schema.schema)
+    private func resolve(_ header: Header) throws {
+        try resolve(header.schema.schema)
     }
 
-    private func resolve(_ requestBody: RequestBody) {
-        resolve(requestBody.content)
+    private func resolve(_ requestBody: RequestBody) throws {
+        try resolve(requestBody.content)
     }
 
-    private func resolve(_ schema: Schema) {
-        resolve(schema.type)
+    private func resolve(_ schema: Schema) throws {
+        try resolve(schema.type)
     }
 
-    private func resolve(_ reference: PossibleReference<Parameter>) {
-        resolveReference(reference, objects: components.parameters)
-        resolve(reference.value)
+    private func resolve(_ reference: PossibleReference<Parameter>) throws {
+        try resolveReference(reference, objects: &components.parameters, resolve)
+        try resolve(reference.value)
     }
 
-    private func resolve(_ parameter: Parameter) {
+    private func resolve(_ parameter: Parameter) throws {
 
         switch parameter.type {
-        case let .schema(schema): resolve(schema.schema)
-        case let .content(content): resolve(content)
+        case let .schema(schema): try resolve(schema.schema)
+        case let .content(content): try resolve(content)
         }
     }
 
-    private func resolve(_ response: OperationResponse) {
-        resolveReference(response.response, objects: components.responses)
+    private func resolve(_ response: OperationResponse) throws {
+        try resolveReference(response.response, objects: &components.responses) {
+            if let content = $0.content {
+                try resolve(content)
+            }
+        }
+
         if let content = response.response.value.content {
-            resolve(content)
+            try resolve(content)
         }
         for reference in response.response.value.headers.values {
-            resolveReference(reference, objects: components.headers)
+            try resolveReference(reference, objects: &components.headers) { _ in }
         }
     }
 
-    private func resolve<T>(_ components: [ComponentObject<T>], _ resolver: (T) -> Void) {
-        components.forEach { resolver($0.value) }
+    private func resolve<T>(_ components: [ComponentObject<T>], _ resolver: (T) throws -> Void) throws {
+        try components.forEach { try resolver($0.value) }
+    }
+    
+    private func url(for ref: String) throws -> URL {
+        guard var url = ComponentResolver.schemeURL else {
+            throw SwaggerError.missingURL
+        }
+        var value = ref.replacingOccurrences(of: "\\/", with: "/")
+        while value.hasPrefix("./") {
+            value.removeFirst(2)
+        }
+        while value.hasPrefix("../") {
+            value.removeFirst(3)
+            url = url.deletingLastPathComponent()
+        }
+        value = value.trimmingCharacters(in: CharacterSet(charactersIn: "./#"))
+        return url.appendingPathComponent(value)
     }
 }

--- a/Sources/Swagger/Component/ComponentResolver.swift
+++ b/Sources/Swagger/Component/ComponentResolver.swift
@@ -82,7 +82,7 @@ class ComponentResolver {
         }
         let json: JSONDictionary
         do {
-        		let string = String(data: data, encoding: .utf8) ?? ""
+            let string = String(data: data, encoding: .utf8) ?? ""
             let yaml = try Yams.load(yaml: string)
             json = yaml as? JSONDictionary ?? [:]
         } catch {
@@ -169,19 +169,14 @@ class ComponentResolver {
     }
     
     private func url(for ref: String) throws -> URL {
+        let ref = ref.replacingOccurrences(of: "\\/", with: "/")
         if let url = URL(string: ref) { return url }
-        guard var url = ComponentResolver.schemeURL else {
+        guard
+            let baseURL = ComponentResolver.schemeURL,
+            let url = URL(string: ref, relativeTo: baseURL)
+        else {
             throw SwaggerError.missingURL
         }
-        var value = ref.replacingOccurrences(of: "\\/", with: "/")
-        while value.hasPrefix("./") {
-            value.removeFirst(2)
-        }
-        while value.hasPrefix("../") {
-            value.removeFirst(3)
-            url = url.deletingLastPathComponent()
-        }
-        value = value.trimmingCharacters(in: CharacterSet(charactersIn: "./#"))
-        return url.appendingPathComponent(value)
+        return url
     }
 }

--- a/Sources/Swagger/Component/ComponentResolver.swift
+++ b/Sources/Swagger/Component/ComponentResolver.swift
@@ -80,9 +80,14 @@ class ComponentResolver {
         } catch {
             throw SwaggerError.loadError(url)
         }
-        let string = String(data: data, encoding: .utf8) ?? ""
-        let yaml = try Yams.load(yaml: string)
-        let json = yaml as? JSONDictionary ?? [:]
+        let json: JSONDictionary
+        do {
+        		let string = String(data: data, encoding: .utf8) ?? ""
+            let yaml = try Yams.load(yaml: string)
+            json = yaml as? JSONDictionary ?? [:]
+        } catch {
+            json = try .from(jsonData: data)
+        }
         let value = try T.init(jsonDictionary: json)
         reference.resolve(with: value)
         let currentURL = ComponentResolver.schemeURL
@@ -164,6 +169,7 @@ class ComponentResolver {
     }
     
     private func url(for ref: String) throws -> URL {
+        if let url = URL(string: ref) { return url }
         guard var url = ComponentResolver.schemeURL else {
             throw SwaggerError.missingURL
         }

--- a/Sources/Swagger/Component/ComponentResolver.swift
+++ b/Sources/Swagger/Component/ComponentResolver.swift
@@ -73,9 +73,6 @@ class ComponentResolver {
     }
     
     private func resolveReference<T: JSONObjectConvertible>(_ reference: Reference<T>, _ resolver: (T) throws -> Void) throws {
-        guard reference.string.hasSuffix("yaml") else {
-            return
-        }
         let url = try url(for: reference.string)
         let data: Data
         do {

--- a/Sources/Swagger/Component/Components.swift
+++ b/Sources/Swagger/Component/Components.swift
@@ -2,12 +2,12 @@ import Foundation
 import JSONUtilities
 
 public struct Components {
-    public let securitySchemes: [ComponentObject<SecurityScheme>]
-    public let schemas: [ComponentObject<Schema>]
-    public let parameters: [ComponentObject<Parameter>]
-    public let responses: [ComponentObject<Response>]
-    public let requestBodies: [ComponentObject<RequestBody>]
-    public let headers: [ComponentObject<Header>]
+    public var securitySchemes: [ComponentObject<SecurityScheme>]
+    public var schemas: [ComponentObject<Schema>]
+    public var parameters: [ComponentObject<Parameter>]
+    public var responses: [ComponentObject<Response>]
+    public var requestBodies: [ComponentObject<RequestBody>]
+    public var headers: [ComponentObject<Header>]
 
 }
 

--- a/Sources/Swagger/SwaggerError.swift
+++ b/Sources/Swagger/SwaggerError.swift
@@ -9,6 +9,7 @@ public enum SwaggerError: Error, CustomStringConvertible {
     case invalidArraySchema([String: Any])
     case loadError(URL)
     case parseError(String)
+    case missingURL
 
     public var description: String {
         switch self {
@@ -25,6 +26,8 @@ public enum SwaggerError: Error, CustomStringConvertible {
             return "Couldn't load url \(url)"
         case let .parseError(message):
             return "Swagger Parsing Error \(message)"
+        case .missingURL:
+            return "Missing schema URL"
         }
     }
 }

--- a/Sources/Swagger/SwaggerSpec.swift
+++ b/Sources/Swagger/SwaggerSpec.swift
@@ -5,15 +5,15 @@ import Yams
 
 public struct SwaggerSpec {
 
-    public let json: [String: Any]
-    public let version: String
-    public let info: Info
-    public let paths: [Path]
-    public let servers: [Server]
-    public let components: Components
-    public let securityRequirements: [SecurityRequirement]?
+    public var json: [String: Any]
+    public var version: String
+    public var info: Info
+    public var paths: [Path]
+    public var servers: [Server]
+    public var components: Components
+    public var securityRequirements: [SecurityRequirement]?
 
-    public let operations: [Operation]
+    public var operations: [Operation]
 
     public var tags: [String] {
         let tags: [String] = operations.reduce([]) { $0 + $1.tags }
@@ -42,7 +42,7 @@ extension SwaggerSpec {
         } catch {
             throw SwaggerError.loadError(url)
         }
-
+        ComponentResolver.schemeURL = url
         if let string = String(data: data, encoding: .utf8) {
             try self.init(string: string)
         } else if let string = String(data: data, encoding: .ascii) {
@@ -107,6 +107,7 @@ extension SwaggerSpec: JSONObjectConvertible {
             })
 
         let resolver = ComponentResolver(spec: self)
-        resolver.resolve()
+        try resolver.resolve()
+        self = resolver.spec
     }
 }


### PR DESCRIPTION
The OpenAPI specification supports the use of external JSON or YAML files through references, but generating code from specifications that include external references is currently not possible with SwagGen. However, this pull request adds the capability to SwagGen to generate code from OpenAPI specs with external references.