### PR TITLE
Add 'explode' serialization parameter handling

### DIFF
--- a/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEnumParameters.swift
+++ b/Specs/PetstoreTest/generated/Swift/Sources/Requests/Fake/TestEnumParameters.swift
@@ -118,7 +118,7 @@ extension PetstoreTest.Fake {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let enumQueryStringArray = options.enumQueryStringArray?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let enumQueryStringArray = options.enumQueryStringArray?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "enumQueryStringArray=\(item)" }.joined(separator: "&") {
                   params["enum_query_string_array"] = enumQueryStringArray
                 }
                 if let enumQueryString = options.enumQueryString?.encode() {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Journey/JourneyJourneyResults.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Journey/JourneyJourneyResults.swift
@@ -199,10 +199,10 @@ extension TFL.Journey {
                 if let journeyPreference = options.journeyPreference?.encode() {
                   params["journeyPreference"] = journeyPreference
                 }
-                if let mode = options.mode?.joined(separator: ",") {
+                if let mode = options.mode?.enumerated().map { number, item in return number == 0 ? item : "mode=\(item)" }.joined(separator: "&") {
                   params["mode"] = mode
                 }
-                if let accessibilityPreference = options.accessibilityPreference?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let accessibilityPreference = options.accessibilityPreference?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "accessibilityPreference=\(item)" }.joined(separator: "&") {
                   params["accessibilityPreference"] = accessibilityPreference
                 }
                 if let fromName = options.fromName {
@@ -229,7 +229,7 @@ extension TFL.Journey {
                 if let adjustment = options.adjustment {
                   params["adjustment"] = adjustment
                 }
-                if let bikeProficiency = options.bikeProficiency?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let bikeProficiency = options.bikeProficiency?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "bikeProficiency=\(item)" }.joined(separator: "&") {
                   params["bikeProficiency"] = bikeProficiency
                 }
                 if let alternativeCycle = options.alternativeCycle {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineLineRoutesByIds.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineLineRoutesByIds.swift
@@ -53,7 +53,7 @@ extension TFL.Line {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "serviceTypes=\(item)" }.joined(separator: "&") {
                   params["serviceTypes"] = serviceTypes
                 }
                 return params

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRoute.swift
@@ -45,7 +45,7 @@ extension TFL.Line {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "serviceTypes=\(item)" }.joined(separator: "&") {
                   params["serviceTypes"] = serviceTypes
                 }
                 return params

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteByMode.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteByMode.swift
@@ -53,7 +53,7 @@ extension TFL.Line {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "serviceTypes=\(item)" }.joined(separator: "&") {
                   params["serviceTypes"] = serviceTypes
                 }
                 return params

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteSequence.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineRouteSequence.swift
@@ -68,7 +68,7 @@ extension TFL.Line {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "serviceTypes=\(item)" }.joined(separator: "&") {
                   params["serviceTypes"] = serviceTypes
                 }
                 if let excludeCrowding = options.excludeCrowding {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Line/LineSearch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Line/LineSearch.swift
@@ -57,10 +57,10 @@ extension TFL.Line {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let modes = options.modes?.joined(separator: ",") {
+                if let modes = options.modes?.enumerated().map { number, item in return number == 0 ? item : "modes=\(item)" }.joined(separator: "&") {
                   params["modes"] = modes
                 }
-                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "serviceTypes=\(item)" }.joined(separator: "&") {
                   params["serviceTypes"] = serviceTypes
                 }
                 return params

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetByGeoBox.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceGetByGeoBox.swift
@@ -64,13 +64,13 @@ extension TFL.Place {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let categories = options.categories?.joined(separator: ",") {
+                if let categories = options.categories?.enumerated().map { number, item in return number == 0 ? item : "categories=\(item)" }.joined(separator: "&") {
                   params["categories"] = categories
                 }
                 if let includeChildren = options.includeChildren {
                   params["includeChildren"] = includeChildren
                 }
-                if let type = options.type?.joined(separator: ",") {
+                if let type = options.type?.enumerated().map { number, item in return number == 0 ? item : "type=\(item)" }.joined(separator: "&") {
                   params["type"] = type
                 }
                 if let activeOnly = options.activeOnly {

--- a/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceSearch.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Place/PlaceSearch.swift
@@ -44,7 +44,7 @@ extension TFL.Place {
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
                 params["name"] = options.name
-                if let types = options.types?.joined(separator: ",") {
+                if let types = options.types?.enumerated().map { number, item in return number == 0 ? item : "types=\(item)" }.joined(separator: "&") {
                   params["types"] = types
                 }
                 return params

--- a/Specs/TFL/generated/Swift/Sources/Requests/Road/GetRoadDisruption.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/Road/GetRoadDisruption.swift
@@ -62,10 +62,10 @@ extension TFL.Road {
                 if let stripContent = options.stripContent {
                   params["stripContent"] = stripContent
                 }
-                if let severities = options.severities?.joined(separator: ",") {
+                if let severities = options.severities?.enumerated().map { number, item in return number == 0 ? item : "severities=\(item)" }.joined(separator: "&") {
                   params["severities"] = severities
                 }
-                if let categories = options.categories?.joined(separator: ",") {
+                if let categories = options.categories?.enumerated().map { number, item in return number == 0 ? item : "categories=\(item)" }.joined(separator: "&") {
                   params["categories"] = categories
                 }
                 if let closures = options.closures {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/SearchStopPoints.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/SearchStopPoints.swift
@@ -61,7 +61,7 @@ extension TFL.StopPoint {
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
                 params["query"] = options.query
-                if let modes = options.modes?.joined(separator: ",") {
+                if let modes = options.modes?.enumerated().map { number, item in return number == 0 ? item : "modes=\(item)" }.joined(separator: "&") {
                   params["modes"] = modes
                 }
                 if let faresOnly = options.faresOnly {
@@ -70,7 +70,7 @@ extension TFL.StopPoint {
                 if let maxResults = options.maxResults {
                   params["maxResults"] = maxResults
                 }
-                if let lines = options.lines?.joined(separator: ",") {
+                if let lines = options.lines?.enumerated().map { number, item in return number == 0 ? item : "lines=\(item)" }.joined(separator: "&") {
                   params["lines"] = lines
                 }
                 if let includeHubs = options.includeHubs {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/SearchStopPointsByPath.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/SearchStopPointsByPath.swift
@@ -64,7 +64,7 @@ extension TFL.StopPoint {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let modes = options.modes?.joined(separator: ",") {
+                if let modes = options.modes?.enumerated().map { number, item in return number == 0 ? item : "modes=\(item)" }.joined(separator: "&") {
                   params["modes"] = modes
                 }
                 if let faresOnly = options.faresOnly {
@@ -73,7 +73,7 @@ extension TFL.StopPoint {
                 if let maxResults = options.maxResults {
                   params["maxResults"] = maxResults
                 }
-                if let lines = options.lines?.joined(separator: ",") {
+                if let lines = options.lines?.enumerated().map { number, item in return number == 0 ? item : "lines=\(item)" }.joined(separator: "&") {
                   params["lines"] = lines
                 }
                 if let includeHubs = options.includeHubs {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByGeoPoint.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetByGeoPoint.swift
@@ -65,17 +65,17 @@ extension TFL.StopPoint {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                params["stopTypes"] = options.stopTypes.joined(separator: ",")
+                params["stopTypes"] = options.stopTypes.enumerated().map { number, item in return number == 0 ? item : "stopTypes=\(item)" }.joined(separator: "&")
                 if let radius = options.radius {
                   params["radius"] = radius
                 }
                 if let useStopPointHierarchy = options.useStopPointHierarchy {
                   params["useStopPointHierarchy"] = useStopPointHierarchy
                 }
-                if let modes = options.modes?.joined(separator: ",") {
+                if let modes = options.modes?.enumerated().map { number, item in return number == 0 ? item : "modes=\(item)" }.joined(separator: "&") {
                   params["modes"] = modes
                 }
-                if let categories = options.categories?.joined(separator: ",") {
+                if let categories = options.categories?.enumerated().map { number, item in return number == 0 ? item : "categories=\(item)" }.joined(separator: "&") {
                   params["categories"] = categories
                 }
                 if let returnLines = options.returnLines {

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetServiceTypes.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointGetServiceTypes.swift
@@ -48,10 +48,10 @@ extension TFL.StopPoint {
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
                 params["id"] = options.id
-                if let lineIds = options.lineIds?.joined(separator: ",") {
+                if let lineIds = options.lineIds?.enumerated().map { number, item in return number == 0 ? item : "lineIds=\(item)" }.joined(separator: "&") {
                   params["lineIds"] = lineIds
                 }
-                if let modes = options.modes?.joined(separator: ",") {
+                if let modes = options.modes?.enumerated().map { number, item in return number == 0 ? item : "modes=\(item)" }.joined(separator: "&") {
                   params["modes"] = modes
                 }
                 return params

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointReachableFrom.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointReachableFrom.swift
@@ -57,7 +57,7 @@ extension TFL.StopPoint {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "serviceTypes=\(item)" }.joined(separator: "&") {
                   params["serviceTypes"] = serviceTypes
                 }
                 return params

--- a/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointRoute.swift
+++ b/Specs/TFL/generated/Swift/Sources/Requests/StopPoint/StopPointRoute.swift
@@ -53,7 +53,7 @@ extension TFL.StopPoint {
 
             public override var queryParameters: [String: Any] {
                 var params: [String: Any] = [:]
-                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).joined(separator: ",") {
+                if let serviceTypes = options.serviceTypes?.encode().map({ String(describing: $0) }).enumerated().map { number, item in return number == 0 ? item : "serviceTypes=\(item)" }.joined(separator: "&") {
                   params["serviceTypes"] = serviceTypes
                 }
                 return params


### PR DESCRIPTION
Motivation:

At the moment, the explode parameter is ignored and not processed, although the openapi spec may contain this parameter.

Based on https://swagger.io/docs/specification/serialization/